### PR TITLE
[CYP] - Search & navigate to pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ cache: yarn
 install: yarn install
 script:
 - "$(yarn bin)/cypress run --record --key $cypressDashboard -c baseUrl=$baseURL --env
-  CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken"
+  CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_BASE_URL=$crdsBaseUrl"
 notifications:
   slack: crdschurch:iZZLQf36DkUtiv0SqLhlOklj

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -6,6 +6,7 @@ Environment variables needed to run locally:
 CYPRESS_CONTENTFUL_ACCESS_TOKEN
 CYPRESS_CONTENTFUL_SPACE_ID
 CYPRESS_CONTENTFUL_ENV
+CYPRESS_CRDS_BASE_URL #https://int.crossroads.net
 ```
 
 
@@ -18,6 +19,7 @@ RUN_CYPRESS #true/false
 TRAVIS_CI #Travis's API Authentication token
 CYPRESS_INSTALL_BINARY = 0
 SITE_URL #https://int.crossroads.net/search
+CRDS_BASE_URL #https://int.crossroads.net
 ```
 
 ## Run Locally

--- a/cypress/integration/no_results_spec.js
+++ b/cypress/integration/no_results_spec.js
@@ -1,10 +1,5 @@
 import { Formatter } from '../support/Formatter';
-
-function searchForKeyword(keyword) {
-  cy.get('.ais-SearchBox-input').as('searchField');
-  cy.get('@searchField').clear();
-  cy.get('@searchField').type(keyword);
-}
+import { SearchBar } from '../support/SearchBar';
 
 describe('Concerning searches with no results:', function () {
   beforeEach(function (){
@@ -13,7 +8,7 @@ describe('Concerning searches with no results:', function () {
 
   it('When a keyword returns no results, the expected "no results" message is displayed', function () {
     const noResultsKeyword = 'a7'
-    searchForKeyword(noResultsKeyword);
+    SearchBar.enterKeyword(noResultsKeyword);
 
     cy.get('app-no-results').find('.no-results').as('noResultsBlock');
     cy.get('@noResultsBlock').should('be.visible');
@@ -27,7 +22,7 @@ describe('Concerning searches with no results:', function () {
 
   it('When a keyword returns no results, links to other pages are displayed', function () {
     const noResultsKeyword = 'a7'
-    searchForKeyword(noResultsKeyword);
+    SearchBar.enterKeyword(noResultsKeyword);
 
     cy.get('app-no-results').find('.no-results').as('noResultsBlock');
     cy.get('@noResultsBlock').should('be.visible');
@@ -42,10 +37,10 @@ describe('Concerning searches with no results:', function () {
 
   it('When a successful search is made after a no-results search, results are displayed', function () {
     const noResultsKeyword = 'a7'
-    searchForKeyword(noResultsKeyword);
+    SearchBar.enterKeyword(noResultsKeyword);
 
     const resultsKeyword = 'god'
-    searchForKeyword(resultsKeyword);
+    SearchBar.enterKeyword(resultsKeyword);
 
     cy.get('app-hits').find('app-hit').as('firstResult');
     cy.get('@firstResult').should('be.visible');

--- a/cypress/integration/pre_search_content_spec.js
+++ b/cypress/integration/pre_search_content_spec.js
@@ -1,5 +1,6 @@
 import { ContentfulElementValidator as Element } from '../Contentful/ContentfulElementValidator'
 import { ContentBlockManager } from '../Contentful/Models/ContentBlockModel';
+import { SearchBar } from '../support/SearchBar';
 
 function preSearchContentBlockShouldBeDisplayed(contentBlock) {
   cy.get('app-suggested').find('.suggested-container').as('preSearchContentBlock');
@@ -25,14 +26,14 @@ describe('The pre-search content block should be displayed:', function () {
 
   it('After the search bar is cleared using the icon or manually', function () {
     const searchString = 'a'
-    cy.get('.ais-SearchBox-input').as('searchField');
-    cy.get('@searchField').type(searchString);
+    SearchBar.enterKeyword(searchString);
 
     cy.get('.ais-SearchBox-reset').as('clearSearchIcon').click();
     preSearchContentBlockShouldBeDisplayed(preSearchContentBlock);
 
-    cy.get('@searchField').type(searchString);
-    cy.get('@searchField').clear();
+    SearchBar.enterKeyword(searchString);
+    SearchBar.clear();
+
     preSearchContentBlockShouldBeDisplayed(preSearchContentBlock);
   });
 });

--- a/cypress/integration/result_navigation_spec.js
+++ b/cypress/integration/result_navigation_spec.js
@@ -1,0 +1,94 @@
+import { SearchBar } from '../support/SearchBar';
+
+//This returns the card title element, not the card
+function findCardTitleByHref(href, aliasForCard) {
+  cy.get(`[class*="hit-title"][href="${href}"]`).as(`${aliasForCard}`);
+}
+
+function shouldNotFindCardWithHref(href) {
+  cy.get(`[class*="hit-title"][href="${href}"]`).should('not.exist');
+}
+
+//If we need this anywhere else, move this to Support
+function getMediaBaseUrl() {
+  let env = /int|demo/g.exec(`${Cypress.env('CRDS_BASE_URL')}`);
+  env = env === null ? '' : env[0];
+  return `https://media${env}.crossroads.net`;
+}
+
+describe('Given a result indexed from a Page, When that link is clicked, Then the expected page opens:', function () {
+  beforeEach(function () {
+    cy.visit('/');
+  });
+
+  it('Keyword: "Woman Camp Signup" - page requires validation', function () {
+    const womanCampSignupUrl = `${Cypress.env('CRDS_BASE_URL')}/womancamp/signup/`;
+    SearchBar.enterKeyword('Woman Camp Signup');
+
+    findCardTitleByHref(womanCampSignupUrl, 'womanCampSignupCard');
+    cy.get('@womanCampSignupCard').should('exist').and('be.visible');
+
+    cy.get('@womanCampSignupCard').click();
+    cy.contains('Sign In').should('exist').and('be.visible');
+    cy.url().should('eq', `${Cypress.env('CRDS_BASE_URL')}/signin`);
+  });
+
+  it('Keyword: "Woman Camp" - just an ordinary page', function () {
+    const womanCampUrl = `${Cypress.env('CRDS_BASE_URL')}/womancamp/`;
+    SearchBar.enterKeyword('Woman Camp');
+
+    findCardTitleByHref(womanCampUrl, 'womanCampCard');
+    cy.get('@womanCampCard').should('exist').and('be.visible');
+
+    cy.get('@womanCampCard').first().click();
+    cy.url().should('eq', womanCampUrl);
+  });
+
+  it('Keyword: "Locker Room" - page excluded from search', function () {
+    const lockerRoomUrl = `${Cypress.env('CRDS_BASE_URL')}/lockerroom`;
+    SearchBar.enterKeyword('Locker Room');
+
+    shouldNotFindCardWithHref(lockerRoomUrl);
+  })
+})
+
+describe('Given a result indexed from a System Page, When that link is clicked, Then the expected page opens:', function () {
+  beforeEach(function () {
+    cy.visit('/');
+  });
+
+  it('Keyword: "Live Streaming" - page lives in crds-net', function () {
+    const liveUrl = `${Cypress.env('CRDS_BASE_URL')}/live`;
+    SearchBar.enterKeyword('Live Streaming');
+
+    findCardTitleByHref(liveUrl, 'liveStreamingCard');
+    cy.get('@liveStreamingCard').should('exist').and('be.visible');
+
+    cy.get('@liveStreamingCard').click();
+    cy.get('#recent-message-btn').as('watchMessageButton').should('exist').and('be.visible');
+  })
+
+  it('Keyword: "Corkboard" - pages lives in crds-corkboard and is an angular page', function () {
+    const corkboardUrl = `${Cypress.env('CRDS_BASE_URL')}/corkboard`;
+    SearchBar.enterKeyword('Corkboard');
+
+    findCardTitleByHref(corkboardUrl, 'corkboardCard');
+    cy.get('@corkboardCard').should('exist').and('be.visible');
+
+    cy.get('@corkboardCard').click();
+    cy.get('[href="/corkboard/need"]', { timeout: 20000 }).as('corkboardNeedButton').should('exist').and('be.visible');
+  });
+
+  it('Keyword: "Media" - page lives in crds-media and requires a redirect to the media subdomain', function () {
+    const indexedMediaUrl = `${Cypress.env('CRDS_BASE_URL')}/media`;
+    const actualMediaUrl = getMediaBaseUrl();
+    SearchBar.enterKeyword('Media');
+
+    findCardTitleByHref(indexedMediaUrl, 'mediaCard');
+    cy.get('@mediaCard').should('exist').and('be.visible');
+
+    cy.get('@mediaCard').click();
+    cy.get('[data-automation-id="featured-image"').as('featuredImage').should('exist').and('be.visible');
+    cy.url().should('contain', actualMediaUrl);
+  });
+})

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -23,7 +23,7 @@ fi
 # fi
 
 test_this_URL=$SITE_URL
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"crdsBaseUrl\": \"$CRDS_BASE_URL\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
 
 curl -s -X POST \
 -H "Content-Type: application/json" \

--- a/cypress/support/SearchBar.js
+++ b/cypress/support/SearchBar.js
@@ -1,0 +1,14 @@
+export class SearchBar {
+  static enterKeyword(keyword) {
+    SearchBar.clear();
+
+    cy.get('.ais-SearchBox-input').as('searchField');
+    cy.get('@searchField').type(keyword);
+  }
+
+
+  static clear(){
+    cy.get('.ais-SearchBox-input').as('searchField').clear();
+    cy.get('@searchField').should('have.prop', 'value', '');
+  }
+}


### PR DESCRIPTION
Adds tests that search for keywords, clicks the result card and verifies the expected page loads. 
Covers these scenarios: 
- Indexed from System Pages
- Indexed from normal Pages
- Routing to angular page
- Routing to media subdomain (with redirect)
- Routing to Netlify page
- Routing to page requiring authentication
- No results for page marked as "Exclude from search"

Coverage for message and podcast episode results will be added in a future story.