### PR TITLE
[CYP] Message URL tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ cache: yarn
 install: yarn install
 script:
 - "$(yarn bin)/cypress run --record --key $cypressDashboard -c baseUrl=$baseURL --env
-  CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_BASE_URL=$crdsBaseUrl"
+  CONTENTFUL_SPACE_ID=$contentfulSpaceId,CONTENTFUL_ENV=$contentfulEnv,CONTENTFUL_ACCESS_TOKEN=$contentfulToken,CRDS_BASE_URL=$crdsBaseUrl,ALGOLIA_INDEX=$algoliaIndex,ALGOLIA_APP_ID=$algoliaAppId,ALGOLIA_API_KEY=$algoliaApiKey"
 notifications:
   slack: crdschurch:iZZLQf36DkUtiv0SqLhlOklj

--- a/cypress/Algolia/AlgoliaApi.js
+++ b/cypress/Algolia/AlgoliaApi.js
@@ -1,0 +1,16 @@
+import { ResponseWrapper } from '../support/ResponseWrapper';
+
+export class AlgoliaApi{
+  static getQueryResponse(keyword){
+    const responseWrapper = new ResponseWrapper();
+    const encodedKeyword = encodeURI(keyword);
+    cy.request({
+      method: 'POST',
+      url: `https://${Cypress.env('ALGOLIA_APP_ID')}-dsn.algolia.net/1/indexes/*/queries?x-algolia-application-id=${Cypress.env('ALGOLIA_APP_ID')}&x-algolia-api-key=${Cypress.env('ALGOLIA_API_KEY')}`,
+      body: {"requests":[{"indexName": Cypress.env('ALGOLIA_INDEX'),"params":`query=${encodedKeyword}`}]}
+    }).then(response =>{
+      responseWrapper.responseBody = response.body;
+    });
+    return responseWrapper;
+  }
+}

--- a/cypress/Algolia/AlgoliaResultManager.js
+++ b/cypress/Algolia/AlgoliaResultManager.js
@@ -1,0 +1,26 @@
+import { AlgoliaApi } from './AlgoliaApi';
+
+export class AlgoliaResultManager {
+  constructor(){
+    this._results_ready = false;
+  }
+
+  searchForKeyword(keyword){
+    this._results_ready = false;
+    const response = AlgoliaApi.getQueryResponse(keyword);
+    cy.wrap({response}).its('response.responseReady').then(() =>{
+      this._hit_list = response.responseBody.results[0].hits;
+      this._results_ready = true;
+    })
+  }
+
+  getResultByUrl(url){
+    return this._hit_list.find(r => {
+      return r.url === url;
+    });
+  }
+
+  get areResultsReady(){
+    return this._results_ready;
+  }
+}

--- a/cypress/Contentful/ContentfulApi.js
+++ b/cypress/Contentful/ContentfulApi.js
@@ -1,33 +1,16 @@
+import { ResponseWrapper } from '../support/ResponseWrapper';
+
 /*
 * Note: Due to Cypress's async nature, methods requesting data from Contentful may return before the properties within the cy.request blocks have been assigned.
 * Therefore, it is recommended that these methods are called in a before/beforeEach clause to allow more time for data retrieval.
 */
-class ResponseWrapper {
-  constructor () {
-    this._response_ready = false;
-  }
-
-  get responseReady() {
-    return this._response_ready;
-  }
-
-  set responseBody(response) {
-    this._response_body = response;
-    this._response_ready = true;
-  }
-
-  get responseBody() {
-    return this._response_body;
-  }
-}
-
 export class ContentfulApi {
-  static getEntryCollection(query, failOnStatusCode=true) {
+  static getEntryCollection(query, failTestOnErrorCode=true) {
     const responseWrapper = new ResponseWrapper();
     cy.request({
       method: 'GET',
       url: `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/entries?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}&${query}`,
-      failOnStatusCode: failOnStatusCode
+      failOnStatusCode: failTestOnErrorCode
     })
       .then((response) => {
         const jsonResponse = JSON.parse(response.body);
@@ -36,12 +19,12 @@ export class ContentfulApi {
     return responseWrapper;
   }
 
-  static getSingleEntry(id, failOnStatusCode=true) {
+  static getSingleEntry(id, failTestOnErrorCode=true) {
     const responseWrapper = new ResponseWrapper();
     cy.request({
       method: 'GET',
       url: `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/entries/${id}?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}`,
-      failOnStatusCode: failOnStatusCode
+      failOnStatusCode: failTestOnErrorCode
     })
       .then((response) => {
         const jsonResponse = JSON.parse(response.body);
@@ -50,12 +33,12 @@ export class ContentfulApi {
     return responseWrapper;
   }
 
-  static getSingleAsset(id, failOnStatusCode=true) {
+  static getSingleAsset(id, failTestOnErrorCode=true) {
     const responseWrapper = new ResponseWrapper();
     cy.request({
       method: 'GET',
       url: `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/assets/${id}?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}`,
-      failOnStatusCode: failOnStatusCode
+      failOnStatusCode: failTestOnErrorCode
     })
       .then((response) => {
         const jsonResponse = JSON.parse(response.body);

--- a/cypress/Contentful/ContentfulApi.js
+++ b/cypress/Contentful/ContentfulApi.js
@@ -22,12 +22,12 @@ class ResponseWrapper {
 }
 
 export class ContentfulApi {
-  static getEntryCollection(query) {
+  static getEntryCollection(query, failOnStatusCode=true) {
     const responseWrapper = new ResponseWrapper();
     cy.request({
       method: 'GET',
       url: `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/entries?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}&${query}`,
-      failOnStatusCode: false
+      failOnStatusCode: failOnStatusCode
     })
       .then((response) => {
         const jsonResponse = JSON.parse(response.body);
@@ -36,12 +36,26 @@ export class ContentfulApi {
     return responseWrapper;
   }
 
-  static getSingleEntry(id) {
+  static getSingleEntry(id, failOnStatusCode=true) {
     const responseWrapper = new ResponseWrapper();
     cy.request({
       method: 'GET',
       url: `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/entries/${id}?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}`,
-      failOnStatusCode: false
+      failOnStatusCode: failOnStatusCode
+    })
+      .then((response) => {
+        const jsonResponse = JSON.parse(response.body);
+        responseWrapper.responseBody = jsonResponse;
+      });
+    return responseWrapper;
+  }
+
+  static getSingleAsset(id, failOnStatusCode=true) {
+    const responseWrapper = new ResponseWrapper();
+    cy.request({
+      method: 'GET',
+      url: `https://cdn.contentful.com/spaces/${Cypress.env('CONTENTFUL_SPACE_ID')}/environments/${Cypress.env('CONTENTFUL_ENV')}/assets/${id}?access_token=${Cypress.env('CONTENTFUL_ACCESS_TOKEN')}`,
+      failOnStatusCode: failOnStatusCode
     })
       .then((response) => {
         const jsonResponse = JSON.parse(response.body);

--- a/cypress/Contentful/Fields/DateField.js
+++ b/cypress/Contentful/Fields/DateField.js
@@ -1,0 +1,32 @@
+import { ContentfulField } from './ContentfulField';
+
+export class DateField extends ContentfulField {
+  constructor (dateString) {
+    super(dateString);
+
+    if (this.hasContent) {
+      this._content_no_time_zone = this._content.split('T')[0];
+    }
+
+    this._date = this._content;
+  }
+
+  ignoreTimeZone() {
+    if (this.hasContent) {
+      this._date = Cypress.moment(this._content_no_time_zone).format('MM.DD.YYYY');
+    }
+    return this; //Allow chaining
+  }
+
+  toString(format = 'MM.DD.YYYY') {
+    return Cypress.moment(this.date).format(format);
+  }
+
+  compare(dateField) {
+    return dateField.date - this.date;
+  }
+
+  get date() {
+    return new Date(this._date);
+  }
+}

--- a/cypress/Contentful/Fields/ImageField.js
+++ b/cypress/Contentful/Fields/ImageField.js
@@ -1,0 +1,40 @@
+import { ContentfulField } from './ContentfulField';
+import { ContentfulApi } from '../ContentfulApi';
+
+export class ImageField extends ContentfulField {
+  constructor (image) {
+    super(image);
+
+    //Compensate for unpublished assets
+    this._setContentToImageId(image);
+  }
+
+  get id() {
+    return this.hasContent ? this._content : '';
+  }
+
+  //Known defect in Contentful where an unpublished asset can still be linked to a required field
+  get isUnpublished(){
+    return this._is_unpublished === undefined ? false : this._is_unpublished;
+  }
+
+  _setContentToImageId(image) {
+    if (image === undefined)
+      this._content = undefined;
+    else {
+      //If the image asset was unpublished, it will still have an id but will not be displayed on crds.net
+      const imageAsset = ContentfulApi.getSingleAsset(image.sys.id, false);
+      cy.wrap({ imageAsset }).its('imageAsset.responseReady').should('be.true').then(() => {
+        const responseType = imageAsset.responseBody.sys.type;
+        if (responseType != 'Error') {
+          this._content = image.sys.id;
+        }
+        else {
+          //An unpublished asset will still have an id, but may be displayed differently than a missing asset
+          this._content = undefined;
+          this._is_unpublished = true;
+        }
+      });
+    }
+  }
+}

--- a/cypress/Contentful/Models/MessageModel.js
+++ b/cypress/Contentful/Models/MessageModel.js
@@ -1,0 +1,84 @@
+import { TextField } from '../Fields/TextField';
+import { ImageField } from '../Fields/ImageField';
+import { DateField } from '../Fields/DateField';
+import { ContentfulApi } from '../ContentfulApi';
+
+export class MessageManager {
+  saveMostRecentlyUpdatedMessage(){
+    const sortedMessageList = ContentfulApi.getEntryCollection('content_type=message&order=-sys.updatedAt&limit=1');
+    cy.wrap({ sortedMessageList }).its('sortedMessageList.responseReady').should('be.true').then(() => {
+      this._recently_updated_message = new MessageModel(sortedMessageList.responseBody.items[0]);
+    });
+  }
+
+  get recentlyUpdatedMessage(){
+    return this._recently_updated_message;
+  }
+}
+
+export class MessageModel {
+  constructor (responseItem) {
+    this._id = responseItem.sys.id;
+    this._title = new TextField(responseItem.fields.title);
+    this._title.required = true;
+
+    this._slug = new TextField(responseItem.fields.slug);
+    this._slug.required = true;
+
+    this._published_at = new DateField(responseItem.fields.published_at);
+    this._published_at.required = true;
+
+    this._description = new TextField(responseItem.fields.description);
+    this._image = new ImageField(responseItem.fields.image);
+    this._background_image = new ImageField(responseItem.fields.background_image);
+  }
+
+  get id() {
+    return this._id;
+  }
+
+  get title() {
+    return this._title;
+  }
+
+  get slug() {
+    return this._slug;
+  }
+
+  //Series for this message must be stored first
+  get absoluteUrl() {
+    if (this.series === null) {
+      return `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${this.slug.text}`;
+    }
+    else {
+      return `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${this.series.slug.text}/${this.slug.text}`;
+    }
+  }
+
+  get description() {
+    return this._description;
+  }
+
+  get image() {
+    return this._image;
+  }
+
+  get backgroundImage() {
+    return this._background_image;
+  }
+
+  get publishedAt() {
+    return this._published_at;
+  }
+
+  get series() {
+    return this._series;
+  }
+
+  //Set to:
+  //null if series is unpublished or does not exist in Contentful
+  //SeriesModel object if series exists
+  set series(seriesModel) {
+    this._series = seriesModel;
+  }
+}

--- a/cypress/Contentful/Models/MessageModel.js
+++ b/cypress/Contentful/Models/MessageModel.js
@@ -79,6 +79,7 @@ export class MessageModel {
   //null if series is unpublished or does not exist in Contentful
   //SeriesModel object if series exists
   set series(seriesModel) {
+    cy.log(`I'm assigning a series to a message ${seriesModel.title.text}`);//DEBUG
     this._series = seriesModel;
   }
 }

--- a/cypress/Contentful/Models/SeriesModel.js
+++ b/cypress/Contentful/Models/SeriesModel.js
@@ -1,0 +1,118 @@
+import { TextField } from '../Fields/TextField';
+import { ImageField } from '../Fields/ImageField';
+import { DateField } from '../Fields/DateField';
+import { ContentfulApi } from '../ContentfulApi';
+
+export class SeriesManager {
+  // saveCurrentSeries() {
+  //   const seriesList = ContentfulApi.getEntryCollection('content_type=series&select=sys.id,fields.published_at&order=-fields.starts_at&limit=5');
+  //   cy.wrap({ seriesList }).its('seriesList.responseReady').should('be.true').then(() => {
+  //     const responseList = seriesList.responseBody.items;
+
+  //     const now = Date.now();
+  //     const currentSeries = responseList.find(s => {
+  //       return (now >= new Date(s.fields.published_at));
+  //     });
+  //     const seriesEntryId = currentSeries.sys.id;
+
+  //     const seriesFullEntry = ContentfulApi.getSingleEntry(seriesEntryId);
+  //     cy.wrap({ seriesFullEntry }).its('seriesFullEntry.responseReady').should('be.true').then(() => {
+  //       this._current_series = new SeriesModel(seriesFullEntry.responseBody.fields);
+  //     });
+  //   });
+  // }
+
+  saveMessageSeries(messageModel) {
+    const seriesList = ContentfulApi.getEntryCollection('content_type=series&select=sys.id,fields.published_at,fields.videos&order=-fields.starts_at&limit=6');
+    cy.wrap({ seriesList }).its('seriesList.responseReady').should('be.true').then(() => {
+      const responseList = seriesList.responseBody.items;
+
+      const seriesWithMessage = responseList.find(s => {
+        let videoList = s.fields.videos;
+        if (videoList !== undefined)
+          return videoList.find(v => v.sys.id === messageModel.id) !== undefined;
+        return false;
+      });
+
+      //Handle if the series is unpublished
+      if (seriesWithMessage !== undefined) {
+        const seriesFullEntry = ContentfulApi.getSingleEntry(seriesWithMessage.sys.id);
+        cy.wrap({ seriesFullEntry }).its('seriesFullEntry.responseReady').should('be.true').then(() => {
+          messageModel.series = new SeriesModel(seriesFullEntry.responseBody.fields);
+        });
+      }
+      else {
+        messageModel.series = null;
+      }
+    });
+  }
+
+  // get currentSeries() {
+  //   return this._current_series;
+  // }
+}
+
+export class SeriesModel {
+  constructor (responseItem) {
+    this._title = new TextField(responseItem.title);
+    this._title.required = true;
+
+    this._slug = new TextField(responseItem.slug);
+    this._slug.required = true;
+
+    this._description = new TextField(responseItem.description);
+
+    this._published_at = new DateField(responseItem.published_at);
+    this._published_at.required = true;
+
+    this._image = new ImageField(responseItem.image);
+    this._background_image = new ImageField(responseItem.background_image);
+    this._starts_at = new DateField(responseItem.starts_at);
+    this._ends_at = new DateField(responseItem.ends_at);
+    this._youtube_url = new TextField(responseItem.youtube_url);
+  }
+
+  get title() {
+    return this._title;
+  }
+
+  get slug() {
+    return this._slug;
+  }
+
+  get relativeUrl() {
+    return `/series/${this.slug.text}`;
+  }
+
+  get absoluteUrl() {
+    return `${Cypress.env('CRDS_MEDIA_ENDPOINT')}/series/${this.slug.text}`;
+  }
+
+  get description() {
+    return this._description;
+  }
+
+  get image() {
+    return this._image;
+  }
+
+  get backgroundImage() {
+    return this._background_image;
+  }
+
+  get startDate() {
+    return this._starts_at;
+  }
+
+  get endDate() {
+    return this._ends_at;
+  }
+
+  get publishedAt() {
+    return this._published_at;
+  }
+
+  get youtubeURL() {
+    return this._youtube_url;
+  }
+}

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -7,6 +7,7 @@ CYPRESS_CONTENTFUL_ACCESS_TOKEN
 CYPRESS_CONTENTFUL_SPACE_ID
 CYPRESS_CONTENTFUL_ENV
 CYPRESS_CRDS_BASE_URL #https://int.crossroads.net
+CYPRESS_CRDS_MEDIA_ENDPOINT #https://mediaint.crossroads.net
 ```
 
 
@@ -20,6 +21,7 @@ TRAVIS_CI #Travis's API Authentication token
 CYPRESS_INSTALL_BINARY = 0
 SITE_URL #https://int.crossroads.net/search
 CRDS_BASE_URL #https://int.crossroads.net
+CRDS_MEDIA_ENDPOINT #https://mediaint.crossroads.net
 ```
 
 ## Run Locally

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -8,6 +8,9 @@ CYPRESS_CONTENTFUL_SPACE_ID
 CYPRESS_CONTENTFUL_ENV
 CYPRESS_CRDS_BASE_URL #https://int.crossroads.net
 CYPRESS_CRDS_MEDIA_ENDPOINT #https://mediaint.crossroads.net
+CYPRESS_ALGOLIA_INDEX
+CYPRESS_ALGOLIA_APP_ID
+CYPRESS_ALGOLIA_API_KEY
 ```
 
 
@@ -22,6 +25,9 @@ CYPRESS_INSTALL_BINARY = 0
 SITE_URL #https://int.crossroads.net/search
 CRDS_BASE_URL #https://int.crossroads.net
 CRDS_MEDIA_ENDPOINT #https://mediaint.crossroads.net
+ALGOLIA_INDEX
+ALGOLIA_APP_ID
+ALGOLIA_API_KEY
 ```
 
 ## Run Locally

--- a/cypress/integration/results_with_composit_links_spec.js
+++ b/cypress/integration/results_with_composit_links_spec.js
@@ -1,84 +1,47 @@
 import { MessageManager } from '../Contentful/Models/MessageModel';
 import { SeriesManager } from '../Contentful/Models/SeriesModel';
-import { SearchBar } from '../support/SearchBar';
-import { SearchResult } from '../support/SearchResult';
-
-//message urls are series & message, which means modification of part is possible.
-//Same for podcasts+episodes
-
-//find message most recently updated. get series for it. search by series name. verify url matches
-//find series most recently updated. get a message on it (that's published - "video" entry will still exist if message is in draft). search by message name & verify url
-
-//Apply similar logic for podcasts & episodes
+import { AlgoliaResultManager } from '../Algolia/AlgoliaResultManager';
 
 /*
 * Note: Since we are not modifying entries in Contentful, these tests only passively confirm that the message link is stored correctly in Algolia when either the
 * Message or Series slug is updated.
 */
-//TODO we don't care about the look of the results - can we just do a straight API validation?
-describe("Given the link to a message includes its series, When a message or series is updated, Then the message result will have the correct link:", function () {
-  let recentMessage;
-  let messageOnRecentSeries;
+describe("Given that the link to a message includes its series, When a message or series is updated, Then the message result should have the correct link:", function () {
+  let updatedMessage;
+  let messageOnUpdatedSeries;
   before(function () {
+    //Retrieve all our test data here for clearer tests
     const messageManager = new MessageManager();
     const seriesManager = new SeriesManager();
 
     messageManager.saveMostRecentlyUpdatedMessage();
     cy.wrap({ messageManager }).its('messageManager.recentlyUpdatedMessage').should('not.be.undefined').then(() => {
-      recentMessage = messageManager.recentlyUpdatedMessage;
-      seriesManager.saveMessageSeries(recentMessage);
-      cy.wrap({ recentMessage }).its('recentMessage.series').should('not.be.undefined');
+      updatedMessage = messageManager.recentlyUpdatedMessage;
+      seriesManager.saveMessageSeries(updatedMessage);
+      cy.wrap({ updatedMessage }).its('updatedMessage.series').should('not.be.undefined');
     });
 
     seriesManager.saveRecentlyUpdatedSeriesWithMessage();
     cy.wrap({ seriesManager }).its('seriesManager.recentlyUpdatedSeries').should('not.be.undefined').then(() => {
-      messageOnRecentSeries = seriesManager.recentlyUpdatedSeries.getMessageAtIndex(0);
+      messageOnUpdatedSeries = seriesManager.recentlyUpdatedSeries.getMessageAtIndex(0);
     });
-
-    cy.visit('/');
   });
 
-  //TODO - don't search for full name -is too long and unnecessary
-  it('Searching for the most recently updated message', function () {
-    SearchBar.enterKeyword(recentMessage.title.text);
-
-    SearchResult.findResultTitleByHref(recentMessage.absoluteUrl, 'recentMessage');
-    cy.get('@recentMessage').should('exist').and('be.visible');
-  });
-
-  //What if can set value of search bar to full string, then search, not "type"
-  //What if can "type until match found"
-  //Could nav to url with search (but is testing multiple things here)
-
-  it('Searching for a message in the most recently updated series', function () {
-    SearchBar.enterKeyword(messageOnRecentSeries.title.text);
-
-    SearchResult.findResultTitleByHref(messageOnRecentSeries.absoluteUrl, 'messageOnRecentSeries');
-    cy.get('@messageOnRecentSeries').should('exist').and('be.visible');
-  });
-});
-
-describe('just api me', function(){
-  it.only('searches for a thing', function(){
-    cy.request({
-      method: 'POST',
-      url: `https://8y3n3h5pnj-dsn.algolia.net/1/indexes/*/queries?x-algolia-agent=Algolia%20for%20vanilla%20JavaScript%20(lite)%203.32.0%3Bangular-instantsearch%202.1.0%3Binstantsearch.js%202.10.4%3BJS%20Helper%202.26.1&x-algolia-application-id=8Y3N3H5PNJ&x-algolia-api-key=609661e7d659e337fe7a1b5bee6b42f0`,
-      body: {"requests":[{"indexName":"int_crds","params":"query=art&maxValuesPerFacet=9&page=0&highlightPreTag=__ais-highlight__&highlightPostTag=__%2Fais-highlight__&facets=%5B%22contentType%22%2C%22contentType%22%5D&tagFilters="}]}
-    }).then(response =>{
-      expect(response.body.results).to.not.be.undefined;
-      const hitList = response.body.results[0].hits;
-      const result = hitList.find(r => {
-        return r.url === 'https://mediaint.crossroads.net/podcasts/ikr/the-art-of-connecting-with-god';
-      });
-      expect(result).to.not.be.undefined;
-    })
-
-  });
-
-  it.only('test out env vars from TS', function(){
-    //TODO import { environment } from '../../environments/environment';
-    //see if can access variables from this to use in request url
-    //IF this method works through demo, use those defined variables elsewhere instead of duplicating
-
+  it('The most recently updated message should have the correct url', function () {
+    const resultManager = new AlgoliaResultManager();
+    resultManager.searchForKeyword(updatedMessage.title.text);
+    cy.wrap({ resultManager }).its('resultManager.areResultsReady').should('be.true').then(() => {
+      const message = resultManager.getResultByUrl(updatedMessage.absoluteUrl);
+      expect(message).to.not.be.undefined;
+    });
   })
-})
+
+  it('A message in the most recently updated series should have the correct url', function () {
+    const resultManager = new AlgoliaResultManager();
+    resultManager.searchForKeyword(messageOnUpdatedSeries.title.text);
+    cy.wrap({ resultManager }).its('resultManager.areResultsReady').should('be.true').then(() => {
+      const message = resultManager.getResultByUrl(messageOnUpdatedSeries.absoluteUrl);
+      expect(message).to.not.be.undefined;
+    });
+  })
+});

--- a/cypress/integration/results_with_composit_links_spec.js
+++ b/cypress/integration/results_with_composit_links_spec.js
@@ -15,30 +15,70 @@ import { SearchResult } from '../support/SearchResult';
 * Note: Since we are not modifying entries in Contentful, these tests only passively confirm that the message link is stored correctly in Algolia when either the
 * Message or Series slug is updated.
 */
-describe("Given the link to a message includes its series, When a message or series is updated, Then the message result will have the correct link:", function(){
-  before(function(){
+//TODO we don't care about the look of the results - can we just do a straight API validation?
+describe("Given the link to a message includes its series, When a message or series is updated, Then the message result will have the correct link:", function () {
+  let recentMessage;
+  let messageOnRecentSeries;
+  before(function () {
+    const messageManager = new MessageManager();
+    const seriesManager = new SeriesManager();
+
+    messageManager.saveMostRecentlyUpdatedMessage();
+    cy.wrap({ messageManager }).its('messageManager.recentlyUpdatedMessage').should('not.be.undefined').then(() => {
+      recentMessage = messageManager.recentlyUpdatedMessage;
+      seriesManager.saveMessageSeries(recentMessage);
+      cy.wrap({ recentMessage }).its('recentMessage.series').should('not.be.undefined');
+    });
+
+    seriesManager.saveRecentlyUpdatedSeriesWithMessage();
+    cy.wrap({ seriesManager }).its('seriesManager.recentlyUpdatedSeries').should('not.be.undefined').then(() => {
+      messageOnRecentSeries = seriesManager.recentlyUpdatedSeries.getMessageAtIndex(0);
+    });
+
     cy.visit('/');
   });
 
- //TODO - don't search for full name -is too long and unnecessary
- //TODO gather series/message info before test - not liking the embedded
-  it.only('Searching for the most recently updated message', function (){
-    const messageManager = new MessageManager();
-    const seriesManager = new SeriesManager();
-    messageManager.saveMostRecentlyUpdatedMessage();
-    cy.wrap({messageManager}).its('messageManager.recentlyUpdatedMessage').should('not.be.undefined').then(() =>{
-      const updatedMessage = messageManager.recentlyUpdatedMessage;
-      seriesManager.saveMessageSeries(updatedMessage);
-      cy.wrap({updatedMessage}).its('updatedMessage.series').should('not.be.undefined').then(() => {
-        SearchBar.enterKeyword(updatedMessage.title.text);
+  //TODO - don't search for full name -is too long and unnecessary
+  it('Searching for the most recently updated message', function () {
+    SearchBar.enterKeyword(recentMessage.title.text);
 
-        SearchResult.findResultTitleByHref(updatedMessage.absoluteUrl, 'updatedMessage');
-        cy.get('@updatedMessage').should('exist').and('be.visible');
-      });
-    });
+    SearchResult.findResultTitleByHref(recentMessage.absoluteUrl, 'recentMessage');
+    cy.get('@recentMessage').should('exist').and('be.visible');
   });
 
-  it('Searching for a message in the most recently updated series', function (){
+  //What if can set value of search bar to full string, then search, not "type"
+  //What if can "type until match found"
+  //Could nav to url with search (but is testing multiple things here)
 
+  it('Searching for a message in the most recently updated series', function () {
+    SearchBar.enterKeyword(messageOnRecentSeries.title.text);
+
+    SearchResult.findResultTitleByHref(messageOnRecentSeries.absoluteUrl, 'messageOnRecentSeries');
+    cy.get('@messageOnRecentSeries').should('exist').and('be.visible');
   });
 });
+
+describe('just api me', function(){
+  it.only('searches for a thing', function(){
+    cy.request({
+      method: 'POST',
+      url: `https://8y3n3h5pnj-dsn.algolia.net/1/indexes/*/queries?x-algolia-agent=Algolia%20for%20vanilla%20JavaScript%20(lite)%203.32.0%3Bangular-instantsearch%202.1.0%3Binstantsearch.js%202.10.4%3BJS%20Helper%202.26.1&x-algolia-application-id=8Y3N3H5PNJ&x-algolia-api-key=609661e7d659e337fe7a1b5bee6b42f0`,
+      body: {"requests":[{"indexName":"int_crds","params":"query=art&maxValuesPerFacet=9&page=0&highlightPreTag=__ais-highlight__&highlightPostTag=__%2Fais-highlight__&facets=%5B%22contentType%22%2C%22contentType%22%5D&tagFilters="}]}
+    }).then(response =>{
+      expect(response.body.results).to.not.be.undefined;
+      const hitList = response.body.results[0].hits;
+      const result = hitList.find(r => {
+        return r.url === 'https://mediaint.crossroads.net/podcasts/ikr/the-art-of-connecting-with-god';
+      });
+      expect(result).to.not.be.undefined;
+    })
+
+  });
+
+  it.only('test out env vars from TS', function(){
+    //TODO import { environment } from '../../environments/environment';
+    //see if can access variables from this to use in request url
+    //IF this method works through demo, use those defined variables elsewhere instead of duplicating
+
+  })
+})

--- a/cypress/integration/results_with_composit_links_spec.js
+++ b/cypress/integration/results_with_composit_links_spec.js
@@ -1,0 +1,44 @@
+import { MessageManager } from '../Contentful/Models/MessageModel';
+import { SeriesManager } from '../Contentful/Models/SeriesModel';
+import { SearchBar } from '../support/SearchBar';
+import { SearchResult } from '../support/SearchResult';
+
+//message urls are series & message, which means modification of part is possible.
+//Same for podcasts+episodes
+
+//find message most recently updated. get series for it. search by series name. verify url matches
+//find series most recently updated. get a message on it (that's published - "video" entry will still exist if message is in draft). search by message name & verify url
+
+//Apply similar logic for podcasts & episodes
+
+/*
+* Note: Since we are not modifying entries in Contentful, these tests only passively confirm that the message link is stored correctly in Algolia when either the
+* Message or Series slug is updated.
+*/
+describe("Given the link to a message includes its series, When a message or series is updated, Then the message result will have the correct link:", function(){
+  before(function(){
+    cy.visit('/');
+  });
+
+ //TODO - don't search for full name -is too long and unnecessary
+ //TODO gather series/message info before test - not liking the embedded
+  it.only('Searching for the most recently updated message', function (){
+    const messageManager = new MessageManager();
+    const seriesManager = new SeriesManager();
+    messageManager.saveMostRecentlyUpdatedMessage();
+    cy.wrap({messageManager}).its('messageManager.recentlyUpdatedMessage').should('not.be.undefined').then(() =>{
+      const updatedMessage = messageManager.recentlyUpdatedMessage;
+      seriesManager.saveMessageSeries(updatedMessage);
+      cy.wrap({updatedMessage}).its('updatedMessage.series').should('not.be.undefined').then(() => {
+        SearchBar.enterKeyword(updatedMessage.title.text);
+
+        SearchResult.findResultTitleByHref(updatedMessage.absoluteUrl, 'updatedMessage');
+        cy.get('@updatedMessage').should('exist').and('be.visible');
+      });
+    });
+  });
+
+  it('Searching for a message in the most recently updated series', function (){
+
+  });
+});

--- a/cypress/kickOffCypress.sh
+++ b/cypress/kickOffCypress.sh
@@ -23,7 +23,7 @@ fi
 # fi
 
 test_this_URL=$SITE_URL
-body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"crdsBaseUrl\": \"$CRDS_BASE_URL\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
+body="{\"request\": { \"branch\":\"$HEAD\", \"config\": {\"env\": { \"baseURL\": \"$test_this_URL\", \"contentfulSpaceId\": \"$CONTENTFUL_SPACE_ID\", \"contentfulEnv\": \"$CONTENTFUL_ENV\", \"contentfulToken\": \"$CONTENTFUL_ACCESS_TOKEN\", \"crdsBaseUrl\": \"$CRDS_BASE_URL\", \"algoliaIndex\": \"$ALGOLIA_INDEX\", \"algoliaAppId\": \"$ALGOLIA_APP_ID\", \"algoliaApiKey\": \"$ALGOLIA_API_KEY\", \"DEBUG_NetlifyContext\": \"$CONTEXT\"}}}}"
 
 curl -s -X POST \
 -H "Content-Type: application/json" \

--- a/cypress/support/ResponseWrapper.js
+++ b/cypress/support/ResponseWrapper.js
@@ -1,0 +1,18 @@
+export class ResponseWrapper {
+  constructor () {
+    this._response_ready = false;
+  }
+
+  get responseReady() {
+    return this._response_ready;
+  }
+
+  set responseBody(response) {
+    this._response_body = response;
+    this._response_ready = true;
+  }
+
+  get responseBody() {
+    return this._response_body;
+  }
+}

--- a/cypress/support/SearchResult.js
+++ b/cypress/support/SearchResult.js
@@ -2,6 +2,4 @@ export class SearchResult {
   static findResultTitleByHref(href, aliasForCard) {
     cy.get(`[class*="hit-title"][href="${href}"]`).as(`${aliasForCard}`);
   }
-
-
 }

--- a/cypress/support/SearchResult.js
+++ b/cypress/support/SearchResult.js
@@ -1,0 +1,7 @@
+export class SearchResult {
+  static findResultTitleByHref(href, aliasForCard) {
+    cy.get(`[class*="hit-title"][href="${href}"]`).as(`${aliasForCard}`);
+  }
+
+
+}


### PR DESCRIPTION
## Test additions & enhancements
- Added tests confirming a message's url is build correctly using its series
- Added Algolia API so we can test results for a query without using the UI
- Added Message and Series models and related classes (copied from crds-net, so lots of unnecessary classes added)

## Deduping plans
There's now a lot of duplicate classes between crds-search and crds-net related to Contentful content and accessing it. The plan has always been to move this code to crds-cypress-tools so it could be packaged and shared as an npm package. It's finally gone through enough refinement and bug fixes that I think it's stable enough to share, so it will be moved into crds-cypress-tools soon. 