### PR TITLE
[CYP] US16788 - Convert tests to search with modal

### DIFF
--- a/cypress/integration/searchOverlay/no_results_spec.js
+++ b/cypress/integration/searchOverlay/no_results_spec.js
@@ -3,9 +3,15 @@ import { SearchPanelFactory } from '../../support/SearchPanel';
 
 describe('Concerning searches with no results:', function () {
   let search;
+  before(function() {
+    cy.visit('/firstimpressions');
+
+    //DE6720 - force open the modal
+    cy.get('button[data-target="#searchModal"]').first().click({force: true});
+  });
+
   beforeEach(function () {
-    cy.visit('/search');
-    search = SearchPanelFactory.SearchPage();
+    search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   });
 
   it('When a keyword returns no results, the expected "no results" message is displayed', function () {

--- a/cypress/integration/searchOverlay/pre_search_content_spec.js
+++ b/cypress/integration/searchOverlay/pre_search_content_spec.js
@@ -4,15 +4,19 @@ import { SearchPanelFactory } from '../../support/SearchPanel';
 describe('The pre-search content block should be displayed:', function () {
   let preSearchContentBlock;
   let search;
-  beforeEach(function () {
-    cy.visit('/search');
-
+  before(function (){
     const cbqm = new ContentBlockQueryManager()
     cbqm.fetchContentBlockByTitle('suggestedSearch').then(() =>{
       preSearchContentBlock = cbqm.queryResult;
-    })
+    });
+  })
 
-    search = SearchPanelFactory.SearchPage();
+  beforeEach(function () {
+    cy.visit('/firstimpressions');
+
+    //DE6720 - force open the modal
+    cy.get('button[data-target="#searchModal"]').first().click({force: true});
+    search = SearchPanelFactory.MobileSharedHeaderSearchModal();
     search.suggestedSearchBlock.as('preSearchContent');
   });
 

--- a/cypress/integration/searchOverlay/result_navigation_spec.js
+++ b/cypress/integration/searchOverlay/result_navigation_spec.js
@@ -28,7 +28,7 @@ describe('Given a result indexed from a Page, When that link is clicked, Then th
     search.clearedSearchField.type('Woman Camp');
     search.getResultTitlesByHref(womanCampUrl).first().scrollIntoView().as('womanCampCard')
       .should('exist').and('be.visible')
-      .click();
+      .click({ force: true });
 
     cy.url().should('eq', womanCampUrl);
   });
@@ -57,7 +57,7 @@ describe('Given a result indexed from a System Page, When that link is clicked, 
     search.clearedSearchField.type('Live Streaming');
     search.getResultTitlesByHref(liveUrl).first().scrollIntoView().as('liveStreamingCard')
       .should('exist').and('be.visible')
-      .click();
+      .click({ force: true });
 
     cy.get('#recent-message-btn').as('watchMessageButton').should('exist').and('be.visible');
   })

--- a/cypress/integration/searchOverlay/result_navigation_spec.js
+++ b/cypress/integration/searchOverlay/result_navigation_spec.js
@@ -1,44 +1,42 @@
 import { SearchPanelFactory } from '../../support/SearchPanel'
-//TODO test this
+
 describe('Given a result indexed from a Page, When that link is clicked, Then the expected page opens:', function () {
   let search;
   beforeEach(function () {
     cy.visit('/firstimpressions');
 
     //DE6720 - force open the modal
-    cy.get('button[data-target="#searchModal"]').first().click({force: true});
+    cy.get('button[data-target="#searchModal"]').first().click({ force: true });
     search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   });
 
   it('Keyword: "Woman Camp Signup" - page requires validation', function () {
     const womanCampSignupUrl = `${Cypress.config().baseUrl}/womancamp/signup/`;
 
-    search.clearedSearchField.type('Woman Camp Signup').then(() => {
-      search.resultTitlesByHref(womanCampSignupUrl).first().scrollIntoView().as('womanCampSignupCard');
-      cy.get('@womanCampSignupCard').should('exist').and('be.visible');
+    search.clearedSearchField.type('Woman Camp Signup');
+    search.getResultTitlesByHref(womanCampSignupUrl).first().scrollIntoView().as('womanCampSignupCard')
+      .should('exist').and('be.visible')
+      .click({ force: true });
 
-      cy.get('@womanCampSignupCard').click({ force: true });
-      cy.contains('Sign In').should('exist').and('be.visible');
-      cy.url().should('eq', `${Cypress.config().baseUrl}/signin`);
-    });
+    cy.contains('Sign In').should('exist').and('be.visible');
+    cy.url().should('eq', `${Cypress.config().baseUrl}/signin`);
   });
 
   it('Keyword: "Woman Camp" - just an ordinary page', function () {
     const womanCampUrl = `${Cypress.config().baseUrl}/womancamp/`;
 
-    search.clearedSearchField.type('Woman Camp').then(() => {
-      search.resultTitlesByHref(womanCampUrl).first().scrollIntoView().as('womanCampCard');
-      cy.get('@womanCampCard').should('exist').and('be.visible');
+    search.clearedSearchField.type('Woman Camp');
+    search.getResultTitlesByHref(womanCampUrl).first().scrollIntoView().as('womanCampCard')
+      .should('exist').and('be.visible')
+      .click();
 
-      cy.get('@womanCampCard').first().click();
-      cy.url().should('eq', womanCampUrl);
-    });
+    cy.url().should('eq', womanCampUrl);
   });
 
   it('Keyword: "Locker Room" - page excluded from search', function () {
     const lockerRoomUrl = `${Cypress.config().baseUrl}/lockerroom`;
     search.clearedSearchField.type('Locker Room').then(() => {
-      search.resultTitlesByHref(lockerRoomUrl).should('not.exist');
+      search.getResultTitlesByHref(lockerRoomUrl).should('not.exist');
     });
   })
 })
@@ -46,44 +44,45 @@ describe('Given a result indexed from a Page, When that link is clicked, Then th
 describe('Given a result indexed from a System Page, When that link is clicked, Then the expected page opens:', function () {
   let search;
   beforeEach(function () {
-    cy.visit('/search');
-    search = SearchPanelFactory.SearchPage();
+    cy.visit('/firstimpressions');
+
+    //DE6720 - force open the modal
+    cy.get('button[data-target="#searchModal"]').first().click({ force: true });
+    search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   });
 
   it('Keyword: "Live Streaming" - page lives in crds-net', function () {
     const liveUrl = `${Cypress.config().baseUrl}/live`;
 
-    search.clearedSearchField.type('Live Streaming').then(() => {
-      search.resultTitlesByHref(liveUrl).first().scrollIntoView().as('liveStreamingCard');
-      cy.get('@liveStreamingCard').should('exist').and('be.visible');
+    search.clearedSearchField.type('Live Streaming');
+    search.getResultTitlesByHref(liveUrl).first().scrollIntoView().as('liveStreamingCard')
+      .should('exist').and('be.visible')
+      .click();
 
-      cy.get('@liveStreamingCard').click();
-      cy.get('#recent-message-btn').as('watchMessageButton').should('exist').and('be.visible');
-    });
+    cy.get('#recent-message-btn').as('watchMessageButton').should('exist').and('be.visible');
   })
 
   it('Keyword: "Corkboard" - pages lives in crds-corkboard and is an angular page', function () {
     const corkboardUrl = `${Cypress.config().baseUrl}/corkboard`;
 
-    search.clearedSearchField.type('Corkboard').then(() => {
-      search.resultTitlesByHref(corkboardUrl).first().scrollIntoView().as('corkboardCard');
-      cy.get('@corkboardCard').should('exist').and('be.visible');
+    search.clearedSearchField.type('Corkboard');
+    search.getResultTitlesByHref(corkboardUrl).first().scrollIntoView().as('corkboardCard')
+      .should('exist').and('be.visible')
+      .click({ force: true });
 
-      cy.get('@corkboardCard').click({ force: true });
-      cy.get('[href="/corkboard/need"]', { timeout: 20000 }).as('corkboardNeedButton').should('exist').and('be.visible');
-    });
+    cy.get('[href="/corkboard/need"]', { timeout: 20000 }).as('corkboardNeedButton').should('exist').and('be.visible');
   });
 
   it('Keyword: "Media" - page lives in crds-media and requires a redirect to the media subdomain', function () {
     const mediaURL = `${Cypress.config().baseUrl}/media`;
 
-    search.clearedSearchField.type('Media').then(() => {
-      search.resultTitlesByHref(mediaURL).first().scrollIntoView().as('mediaCard');
-      cy.get('@mediaCard').should('exist').and('be.visible');
+    search.clearedSearchField.type('Media');
+    search.getResultTitlesByHref(mediaURL).first().scrollIntoView().as('mediaCard')
+      .should('exist').and('be.visible')
+      .click({ force: true });
 
-      cy.get('@mediaCard').click();
-      cy.get('[data-automation-id="featured-image"').as('featuredImage').should('exist').and('be.visible');
-      cy.url().should('contain', mediaURL);
-    });
+    cy.get('[data-automation-id="featured-image"').as('featuredImage')
+      .should('exist').and('be.visible');
+    cy.url().should('contain', mediaURL);
   });
 })

--- a/cypress/integration/searchOverlay/result_navigation_spec.js
+++ b/cypress/integration/searchOverlay/result_navigation_spec.js
@@ -1,10 +1,13 @@
 import { SearchPanelFactory } from '../../support/SearchPanel'
-
+//TODO test this
 describe('Given a result indexed from a Page, When that link is clicked, Then the expected page opens:', function () {
   let search;
   beforeEach(function () {
-    cy.visit('/search');
-    search = SearchPanelFactory.SearchPage();
+    cy.visit('/firstimpressions');
+
+    //DE6720 - force open the modal
+    cy.get('button[data-target="#searchModal"]').first().click({force: true});
+    search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   });
 
   it('Keyword: "Woman Camp Signup" - page requires validation', function () {

--- a/cypress/integration/searchOverlay/shared_header_search_icon_spec.js
+++ b/cypress/integration/searchOverlay/shared_header_search_icon_spec.js
@@ -1,7 +1,7 @@
 import { SearchPanelFactory } from '../../support/SearchPanel'
 
 describe('The Search modal should be displayed when the search icon is clicked:', function () {
-  const pagesWithSearchIcon = ['/', '/giving', '/live'];
+  const pagesWithSearchIcon = ['/', '/giving', '/live', '/firstimpressions'];
   pagesWithSearchIcon.forEach(url => {
     it(`From ${url}`, function () {
       cy.visit(url);

--- a/cypress/integration/searchPage/search_params_in_url_spec.js
+++ b/cypress/integration/searchPage/search_params_in_url_spec.js
@@ -28,7 +28,7 @@ describe('When someone searches:', function () {
   it('For a keyword and selects filter, the keyword and filter should be included in the url', function () {
     const keyword = 'God';
     search.clearedSearchField.type(keyword).then(() => {
-      search.filterList.eq(1).as('searchFilter'); //Select the second filter
+      search.filterList.eq(1).scrollIntoView().as('searchFilter'); //Select the second filter
 
       cy.get('@searchFilter').find('.ais-Menu-label').should('have.prop', 'textContent').then(label => {
         cy.get('@searchFilter').click();

--- a/cypress/integration/searchPage/search_params_in_url_spec.js
+++ b/cypress/integration/searchPage/search_params_in_url_spec.js
@@ -28,7 +28,7 @@ describe('When someone searches:', function () {
   it('For a keyword and selects filter, the keyword and filter should be included in the url', function () {
     const keyword = 'God';
     search.clearedSearchField.type(keyword).then(() => {
-      search.filterList.last().as('searchFilter');
+      search.filterList.eq(1).as('searchFilter'); //Select the second filter
 
       cy.get('@searchFilter').find('.ais-Menu-label').should('have.prop', 'textContent').then(label => {
         cy.get('@searchFilter').click();

--- a/cypress/support/SearchPanel.js
+++ b/cypress/support/SearchPanel.js
@@ -1,8 +1,8 @@
-export class SearchPanelFactory{
+export class SearchPanelFactory {
   /**
    * Returns the SearchPanel for /search. Test must have /search open before calling this.
    */
-  static SearchPage(){
+  static SearchPage() {
     cy.get('app-root').find('.search-panel').as('searchPanel');
     return new SearchPanel('searchPanel');
   }
@@ -10,64 +10,64 @@ export class SearchPanelFactory{
   /**
    * Returns the SearchPanel for the mobile version of the Shared Header
    */
-  static MobileSharedHeaderSearchModal(){
+  static MobileSharedHeaderSearchModal() {
     cy.get('#mobile-search').find('.search-panel').as('searchPanel');
     return new SearchPanel('searchPanel');
   }
 }
 
 class SearchPanel {
-  constructor(panelAlias){
+  constructor (panelAlias) {
     this.alias = panelAlias;
   }
 
-  get searchField(){
+  get searchField() {
     return cy.get(`@${this.alias}`).find('.ais-SearchBox-input');
   }
 
-  get clearedSearchField(){
+  get clearedSearchField() {
     this.searchField.as('searchField').clear();
     cy.get('@searchField').should('have.prop', 'value', '');
     return this.searchField;
   }
 
   //X in the search field iff it has text
-  get resetIcon(){
+  get resetIcon() {
     return cy.get(`@${this.alias}`).find('.ais-SearchBox-reset');
   }
 
   /**
    * Results/Suggested
    */
-  get suggestedSearchBlock(){
+  get suggestedSearchBlock() {
     return cy.get(`@${this.alias}`).find('.suggested-container');
   }
 
-   get noResultsBlock(){
+  get noResultsBlock() {
     return cy.get(`@${this.alias}`).find('.no-results');
   }
 
-  get resultList(){
+  get resultList() {
     return cy.get(`@${this.alias}`).find('app-hit');
   }
 
   //This doesn't return the full card context - only the title line.
-  resultTitlesByHref(href){
+  getResultTitlesByHref(href) {
     return cy.get(`@${this.alias}`).find(`[class*="hit-title"][href="${href}"]`)
   }
 
   /**
    * Filters
    */
-  get filterList(){
+  get filterList() {
     return cy.get(`@${this.alias}`).find('.ais-Menu-item')
   }
 
-  get filterNames(){
+  get filterNames() {
     return cy.get(`@${this.alias}`).find('.ais-Menu-item').find('.ais-Menu-label');
   }
 
-  get selectedFilter(){
+  get selectedFilter() {
     return cy.get(`@${this.alias}`).find('[class="ais-Menu-item ais-Menu-item--selected"]')
   }
 }

--- a/cypress/support/SearchPanel.js
+++ b/cypress/support/SearchPanel.js
@@ -33,7 +33,7 @@ class SearchPanel {
 
   //X in the search field iff it has text
   get resetIcon(){
-    return cy.get('.ais-SearchBox-reset');
+    return cy.get(`@${this.alias}`).find('.ais-SearchBox-reset');
   }
 
   /**


### PR DESCRIPTION
- Converted tests previously run in /search to use the search modal instead. Tests are now run on /firstimpressions since this page loads aster than other content-heavy pages.
- URL search parameter tests were not converted since they're not compatible with the modal.
- Minor bugs were fixed