### PR TITLE
[CYP] DE6571 - Fix flaky search tests

### DIFF
--- a/cypress/integration/searchOverlay/result_navigation_spec.js
+++ b/cypress/integration/searchOverlay/result_navigation_spec.js
@@ -1,6 +1,6 @@
 import { SearchPanelFactory } from '../../support/SearchPanel'
 
-describe('Given a result indexed from a Page, When that link is clicked, Then the expected page opens:', function () {
+describe.only('Searching for a keyword returns results, and the expected page opens when a result is clicked', function (){
   let search;
   beforeEach(function () {
     cy.visit('/firstimpressions');
@@ -10,7 +10,17 @@ describe('Given a result indexed from a Page, When that link is clicked, Then th
     search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   });
 
-  it('Keyword: "Woman Camp Signup" - page requires validation', function () {
+  it('Searching for an article opens the article in /media', function () {
+    const buyABikiniUrl = `${Cypress.config().baseUrl}/media/articles/god-told-me-to-buy-a-bikini`;
+    search.clearedSearchField.type('Buy a Bikini');
+    search.getResultTitlesByHref(buyABikiniUrl).first().scrollIntoView().as('articleCard')
+      .should('exist').and('be.visible')
+      .click({ force: true });
+
+      cy.url().should('eq', buyABikiniUrl);
+  })
+
+  it('Searching for a page that requires authentication opens /signin', function () {
     const womanCampSignupUrl = `${Cypress.config().baseUrl}/womancamp/signup/`;
 
     search.clearedSearchField.type('Woman Camp Signup');
@@ -20,69 +30,16 @@ describe('Given a result indexed from a Page, When that link is clicked, Then th
 
     cy.contains('Sign In').should('exist').and('be.visible');
     cy.url().should('eq', `${Cypress.config().baseUrl}/signin`);
-  });
-
-  it('Keyword: "Woman Camp" - just an ordinary page', function () {
-    const womanCampUrl = `${Cypress.config().baseUrl}/womancamp/`;
-
-    search.clearedSearchField.type('Woman Camp');
-    search.getResultTitlesByHref(womanCampUrl).first().scrollIntoView().as('womanCampCard')
-      .should('exist').and('be.visible')
-      .click({ force: true });
-
-    cy.url().should('eq', womanCampUrl);
-  });
-
-  it('Keyword: "Locker Room" - page excluded from search', function () {
-    const lockerRoomUrl = `${Cypress.config().baseUrl}/lockerroom`;
-    search.clearedSearchField.type('Locker Room').then(() => {
-      search.getResultTitlesByHref(lockerRoomUrl).should('not.exist');
-    });
-  })
-})
-
-describe('Given a result indexed from a System Page, When that link is clicked, Then the expected page opens:', function () {
-  let search;
-  beforeEach(function () {
-    cy.visit('/firstimpressions');
-
-    //DE6720 - force open the modal
-    cy.get('button[data-target="#searchModal"]').first().click({ force: true });
-    search = SearchPanelFactory.MobileSharedHeaderSearchModal();
-  });
-
-  it('Keyword: "Live Streaming" - page lives in crds-net', function () {
-    const liveUrl = `${Cypress.config().baseUrl}/live`;
-
-    search.clearedSearchField.type('Live Streaming');
-    search.getResultTitlesByHref(liveUrl).first().scrollIntoView().as('liveStreamingCard')
-      .should('exist').and('be.visible')
-      .click({ force: true });
-
-    cy.get('#recent-message-btn').as('watchMessageButton').should('exist').and('be.visible');
   })
 
-  it('Keyword: "Corkboard" - pages lives in crds-corkboard and is an angular page', function () {
-    const corkboardUrl = `${Cypress.config().baseUrl}/corkboard`;
+  it('Searching for an ordinary Contentful page on crds.net opens that page', function () {
+    const jobsUrl = `${Cypress.config().baseUrl}/jobs/`;
 
-    search.clearedSearchField.type('Corkboard');
-    search.getResultTitlesByHref(corkboardUrl).first().scrollIntoView().as('corkboardCard')
+    search.clearedSearchField.type('jobs');
+    search.getResultTitlesByHref(jobsUrl).first().scrollIntoView().as('jobsCard')
       .should('exist').and('be.visible')
       .click({ force: true });
 
-    cy.get('[href="/corkboard/need"]', { timeout: 20000 }).as('corkboardNeedButton').should('exist').and('be.visible');
-  });
-
-  it('Keyword: "Crossroads Media" - page lives in crds-media and requires a redirect to the media subdomain', function () {
-    const mediaURL = `${Cypress.config().baseUrl}/media`;
-
-    search.clearedSearchField.type('Crossroads Media');
-    search.getResultTitlesByHref(mediaURL).first().scrollIntoView().as('mediaCard')
-      .should('exist').and('be.visible')
-      .click({ force: true });
-
-    cy.get('[data-automation-id="featured-image"').as('featuredImage')
-      .should('exist').and('be.visible');
-    cy.url().should('contain', mediaURL);
-  });
+    cy.url().should('eq', jobsUrl);
+  })
 })

--- a/cypress/integration/searchOverlay/result_navigation_spec.js
+++ b/cypress/integration/searchOverlay/result_navigation_spec.js
@@ -1,6 +1,6 @@
 import { SearchPanelFactory } from '../../support/SearchPanel'
 
-describe.only('Searching for a keyword returns results, and the expected page opens when a result is clicked', function (){
+describe('Searching for a keyword returns results, and the expected page opens when a result is clicked', function () {
   let search;
   beforeEach(function () {
     cy.visit('/firstimpressions');
@@ -16,8 +16,7 @@ describe.only('Searching for a keyword returns results, and the expected page op
     search.getResultTitlesByHref(buyABikiniUrl).first().scrollIntoView().as('articleCard')
       .should('exist').and('be.visible')
       .click({ force: true });
-
-      cy.url().should('eq', buyABikiniUrl);
+    cy.url().should('eq', buyABikiniUrl);
   })
 
   it('Searching for a page that requires authentication opens /signin', function () {

--- a/cypress/integration/searchPage/search_params_in_url_spec.js
+++ b/cypress/integration/searchPage/search_params_in_url_spec.js
@@ -9,7 +9,7 @@ function getUrlWithQuery(keyword, filterLabel = undefined) {
   return url;
 }
 
-describe('When someone searches:', function () {
+describe.only('When someone searches:', function () {
   let search;
   beforeEach(function () {
     cy.visit('/search');
@@ -31,7 +31,7 @@ describe('When someone searches:', function () {
       search.filterList.eq(1).scrollIntoView().as('searchFilter'); //Select the second filter
 
       cy.get('@searchFilter').find('.ais-Menu-label').should('have.prop', 'textContent').then(label => {
-        cy.get('@searchFilter').click();
+        cy.get('@searchFilter').click({ force: true });
 
         const expectedUrl = getUrlWithQuery(keyword, label);
         cy.url().should('eq', expectedUrl);

--- a/cypress/integration/searchPage/search_params_in_url_spec.js
+++ b/cypress/integration/searchPage/search_params_in_url_spec.js
@@ -9,7 +9,7 @@ function getUrlWithQuery(keyword, filterLabel = undefined) {
   return url;
 }
 
-describe.only('When someone searches:', function () {
+describe('When someone searches:', function () {
   let search;
   beforeEach(function () {
     cy.visit('/search');


### PR DESCRIPTION
Problem:
- Some tests which searched and clicked the response were flaky - result card existed but could not be clicked. This issue could never be reproduced manually.

Solution/workaround:
- Decided to force click the responses but minimize the risk by limiting the search for & click tests to 3 scenarios: search for article (media subdomain), search for something requiring authentication, search for an ordinary crds-net page. Other scenarios previously covered have been moved to API only tests confirming they have the expected url.