### PR TITLE
[CYP] US16398 - Tests for result card contents

### DIFF
--- a/cypress/integration/APIOnly/index_entries_spec.js
+++ b/cypress/integration/APIOnly/index_entries_spec.js
@@ -2,10 +2,6 @@ import { AlgoliaAPI } from "../../Algolia/AlgoliaAPI";
 
 const expectedEntries = [
   {
-    title: 'Woman Camp Signup',
-    url: `${Cypress.config().baseUrl}/womancamp/signup/`
-  },
-  {
     title: 'Woman Camp',
     url: `${Cypress.config().baseUrl}/womancamp/`
   },
@@ -18,7 +14,7 @@ const expectedEntries = [
     url: `${Cypress.config().baseUrl}/corkboard`
   },
   {
-    title: 'Crossroads Media',
+    title: 'Media',
     url: `${Cypress.config().baseUrl}/media`
   }
 ]

--- a/cypress/integration/APIOnly/response_structure_spec.js
+++ b/cypress/integration/APIOnly/response_structure_spec.js
@@ -4,23 +4,7 @@ import { AlgoliaAPI } from '../../Algolia/AlgoliaAPI';
  * Verifies that the Algolia responses contain what we expect so we know our stubbed responses are accurate.
  */
 const standardProperties = ['title', 'category', 'tags', 'description', 'url', 'objectID', 'image']
-const requiredProperties = {
-  page: [],
-  message: ['date', 'duration', 'date_timestamp', 'series'],
-  series: ['start_date', 'end_date', 'messages', 'date_timestamp'],
-  video: ['date', 'duration', 'date_timestamp'],
-  article: ['date', 'duration', 'date_timestamp', 'author'],
-  episode: ['date', 'duration', 'date_timestamp', 'podcast'],
-  song: ['date', 'duration', 'date_timestamp'],
-  author: [],
-  promo: ['date', 'date_timestamp'],
-  location: ['serviceTimes', 'map_url'],
-  podcast: ['author', 'children_count'],
-  album: ['date', 'duration', 'date_timestamp', 'author'],
-  category: []
-}
-
-const optionalProperties = {
+const contentTypeProperties = {
   page: [],
   message: ['date', 'duration', 'date_timestamp', 'series'],
   series: ['start_date', 'end_date', 'messages', 'date_timestamp'],
@@ -54,7 +38,7 @@ describe('Tests that the responses from the Algilia API have expected properties
     });
   });
 
-  const algoliaContentTypes = Object.keys(requiredProperties);
+  const algoliaContentTypes = Object.keys(contentTypeProperties);
   algoliaContentTypes.forEach(type => {
     it(`Responses for content type "${type}" should have expected properties`, function () {
       AlgoliaAPI.searchByContentType(type).then(response => {
@@ -63,7 +47,7 @@ describe('Tests that the responses from the Algilia API have expected properties
       }).then(firstHit => {
         expect(firstHit).to.have.property('contentType', type);
 
-        const expectedProperties = standardProperties.concat(requiredProperties[type]);
+        const expectedProperties = standardProperties.concat(contentTypeProperties[type]);
         expectedProperties.forEach(prop => {
           expect(firstHit).to.have.property(prop).and.to.not.be.undefined;
         })

--- a/cypress/integration/APIOnly/response_structure_spec.js
+++ b/cypress/integration/APIOnly/response_structure_spec.js
@@ -3,9 +3,8 @@ import { AlgoliaAPI } from '../../Algolia/AlgoliaAPI';
 /**
  * Verifies that the Algolia responses contain what we expect so we know our stubbed responses are accurate.
  */
-
 const standardProperties = ['title', 'category', 'tags', 'description', 'url', 'objectID', 'image']
-const contentTypeProperties = {
+const requiredProperties = {
   page: [],
   message: ['date', 'duration', 'date_timestamp', 'series'],
   series: ['start_date', 'end_date', 'messages', 'date_timestamp'],
@@ -17,8 +16,24 @@ const contentTypeProperties = {
   promo: ['date', 'date_timestamp'],
   location: ['serviceTimes', 'map_url'],
   podcast: ['author', 'children_count'],
-  category: [],
   album: ['date', 'duration', 'date_timestamp', 'author'],
+  category: []
+}
+
+const optionalProperties = {
+  page: [],
+  message: ['date', 'duration', 'date_timestamp', 'series'],
+  series: ['start_date', 'end_date', 'messages', 'date_timestamp'],
+  video: ['date', 'duration', 'date_timestamp'],
+  article: ['date', 'duration', 'date_timestamp', 'author'],
+  episode: ['date', 'duration', 'date_timestamp', 'podcast'],
+  song: ['date', 'duration', 'date_timestamp'],
+  author: [],
+  promo: ['date', 'date_timestamp'],
+  location: ['serviceTimes', 'map_url'],
+  podcast: ['author', 'children_count'],
+  album: ['date', 'duration', 'date_timestamp', 'author'],
+  category: []
 }
 
 describe('Tests that the responses from the Algilia API have expected properties', function (){
@@ -39,9 +54,8 @@ describe('Tests that the responses from the Algilia API have expected properties
     });
   });
 
-  const algoliaContentTypes = Object.keys(contentTypeProperties);
+  const algoliaContentTypes = Object.keys(requiredProperties);
   algoliaContentTypes.forEach(type => {
-
     it(`Responses for content type "${type}" should have expected properties`, function () {
       AlgoliaAPI.searchByContentType(type).then(response => {
         expect(response).to.have.property('hits').with.property('length').gte('0');
@@ -49,7 +63,7 @@ describe('Tests that the responses from the Algilia API have expected properties
       }).then(firstHit => {
         expect(firstHit).to.have.property('contentType', type);
 
-        const expectedProperties = standardProperties.concat(contentTypeProperties[type]);
+        const expectedProperties = standardProperties.concat(requiredProperties[type]);
         expectedProperties.forEach(prop => {
           expect(firstHit).to.have.property(prop).and.to.not.be.undefined;
         })

--- a/cypress/integration/searchOverlay/no_results_spec.js
+++ b/cypress/integration/searchOverlay/no_results_spec.js
@@ -14,7 +14,7 @@ describe('Concerning searches with no results:', function () {
     search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   });
 
-  it.only('When a keyword returns no results, the expected "no results" message is displayed', function () {
+  it('When a keyword returns no results, the expected "no results" message is displayed', function () {
     const noResultsKeyword = 'a7'
     search.clearedSearchField.type(noResultsKeyword).then(() => {
       search.results.noResultsBlock.as('noResultsBlock').should('be.visible')

--- a/cypress/integration/searchOverlay/no_results_spec.js
+++ b/cypress/integration/searchOverlay/no_results_spec.js
@@ -3,34 +3,31 @@ import { SearchPanelFactory } from '../../support/SearchPanel';
 
 describe('Concerning searches with no results:', function () {
   let search;
-  before(function() {
-    cy.visit('/firstimpressions');
+  before(function () {
+    cy.visit('/prayer');
 
     //DE6720 - force open the modal
-    cy.get('button[data-target="#searchModal"]').first().click({force: true});
+    cy.get('button[data-target="#searchModal"]').first().click({ force: true });
   });
 
   beforeEach(function () {
     search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   });
 
-  it('When a keyword returns no results, the expected "no results" message is displayed', function () {
+  it.only('When a keyword returns no results, the expected "no results" message is displayed', function () {
     const noResultsKeyword = 'a7'
     search.clearedSearchField.type(noResultsKeyword).then(() => {
-      search.noResultsBlock.as('noResultsBlock').should('be.visible');
+      search.results.noResultsBlock.as('noResultsBlock').should('be.visible')
+        .find('[data-automation-id="no-results-message"]').as('noResultsMessage');
 
-      //No results text matches
-      cy.get('@noResultsBlock').find('[data-automation-id="no-results-message"]').as('noResultsMessage');
-      cy.get('@noResultsMessage').should('have.prop', 'textContent').then($elementText => {
-        expect(Formatter.normalizeText($elementText)).to.contain(Formatter.normalizeText(`We can't find anything for ${noResultsKeyword}.`));
-      });
+      cy.get('@noResultsMessage').text().should('eq', `We can't find anything for ${noResultsKeyword}.`);
     });
   });
 
   it('When a keyword returns no results, links to other pages are displayed', function () {
     const noResultsKeyword = 'a7'
     search.clearedSearchField.type(noResultsKeyword).then(() => {
-      search.noResultsBlock.as('noResultsBlock').should('be.visible');
+      search.results.noResultsBlock.as('noResultsBlock').should('be.visible');
 
       //Expected urls exist
       cy.get('@noResultsBlock').find('[data-automation-id="no-results-corkboard-link"]').as('corkboardLink');
@@ -38,8 +35,8 @@ describe('Concerning searches with no results:', function () {
 
       cy.get('@noResultsBlock').find('[data-automation-id="no-results-groups-link"]').as('groupsLink');
       cy.get('@groupsLink').should('be.visible').and('has.attr', 'href').and('contains', `/groups/search`);
-    })
-  })
+    });
+  });
 
   it('When a successful search is made after a no-results search, results are displayed', function () {
     const noResultsKeyword = 'a7'
@@ -47,8 +44,8 @@ describe('Concerning searches with no results:', function () {
 
     const resultsKeyword = 'god'
     search.clearedSearchField.type(resultsKeyword).then(() => {
-      search.resultList.first().as('firstResult').should('be.visible');
-      search.noResultsBlock.should('not.exist');
+      search.results.firstCard.title.should('be.visible');
+      search.results.noResultsBlock.should('not.exist');
     });
   });
-})
+});

--- a/cypress/integration/searchOverlay/pre_search_content_spec.js
+++ b/cypress/integration/searchOverlay/pre_search_content_spec.js
@@ -4,43 +4,50 @@ import { SearchPanelFactory } from '../../support/SearchPanel';
 describe('The pre-search content block should be displayed:', function () {
   let preSearchContentBlock;
   let search;
-  before(function (){
+  before(function () {
     const cbqm = new ContentBlockQueryManager()
-    cbqm.fetchContentBlockByTitle('suggestedSearch').then(() =>{
+    cbqm.fetchContentBlockByTitle('suggestedSearch').then(() => {
       preSearchContentBlock = cbqm.queryResult;
     });
   })
 
   beforeEach(function () {
-    cy.visit('/firstimpressions');
+    cy.visit('/prayer');
 
     //DE6720 - force open the modal
-    cy.get('button[data-target="#searchModal"]').first().click({force: true});
+    cy.get('button[data-target="#searchModal"]').first().click({ force: true });
     search = SearchPanelFactory.MobileSharedHeaderSearchModal();
-    search.suggestedSearchBlock.as('preSearchContent');
   });
 
   it('Before a search', function () {
-    cy.get('@preSearchContent').should('be.visible').displayedText().then(elementText =>{
-      expect(elementText).to.contain(preSearchContentBlock.content.displayedText);
+    search.results.suggestedSearchBlock.as('preSearchContent')
+      .should('be.visible')
+      .displayedText().should('contain', preSearchContentBlock.content.displayedText);
+  });
+
+
+  it('After the search bar is cleared using the icon', function () {
+    const searchString = 'a'
+    search.clearedSearchField.type(searchString).then(() => {
+      search.results.firstCard.title.should('be.visible').then(() => {
+        search.resetIcon.as('clearSearchIcon').click();
+        search.results.suggestedSearchBlock.as('preSearchContent')
+          .should('be.visible')
+          .displayedText().should('contain', preSearchContentBlock.content.displayedText);
+      })
     })
   });
 
-  it('After the search bar is cleared using the icon or manually', function () {
+  it('After the search bar is cleared manually', function () {
     const searchString = 'a'
-    search.clearedSearchField.type(searchString).then(() => {
-      search.resetIcon.as('clearSearchIcon').click();
-      cy.get('@preSearchContent').should('be.visible').displayedText().then(elementText =>{
-        expect(elementText).to.contain(preSearchContentBlock.content.displayedText);
-      })
-    })
-
     search.searchField.type(searchString).then(() => {
-      search.clearedSearchField;
-
-      cy.get('@preSearchContent').should('be.visible').displayedText().then(elementText =>{
-        expect(elementText).to.contain(preSearchContentBlock.content.displayedText);
-      })
+      search.results.firstCard.title.should('be.visible').then(() => {
+        search.clearedSearchField.then(() => {
+          search.results.suggestedSearchBlock.as('preSearchContent')
+            .should('be.visible')
+            .displayedText().should('contain', preSearchContentBlock.content.displayedText);
+        });
+      });
     });
   });
 });

--- a/cypress/integration/searchOverlay/result_card_format_spec.js
+++ b/cypress/integration/searchOverlay/result_card_format_spec.js
@@ -1,9 +1,123 @@
-import { SearchPanelFactory, ResultCard, TheFilter } from "../../support/SearchPanel";
+import { SearchPanelFactory, ResultCard } from "../../support/SearchPanel";
 
 //Tests the results are formatted by content
+const resultContentSpecs = [
+  {
+    keyword: 'God',
+    filter: 'page',
+    cardComponents: ['title', 'description', 'hitUrl']
+  },
+  {
+    keyword: 'God',
+    filter: 'message',
+    cardComponents: ['title', 'description', 'image', 'imageTimestampOverlay', 'date', 'series']
+  },
+  {
+    keyword: 'God',
+    filter: 'series',
+    cardComponents: ['title', 'description', 'image', 'seriesDate']
+  },
+  {
+    keyword: 'God',
+    filter: 'video',
+    cardComponents: ['title', 'description', 'image', 'imageTimestampOverlay', 'date', 'category']
+  },
+  {
+    keyword: 'God',
+    filter: 'article',
+    cardComponents: ['title', 'description', 'image', 'imageTimestampOverlay', 'date', 'category', 'author']
+  },
+  {
+    keyword: 'God',
+    filter: 'episode',
+    cardComponents: ['title', 'description', 'image', 'imageTimestampOverlay', 'date', 'category']
+  },
+  {
+    keyword: 'God',
+    filter: 'song',
+    cardComponents: ['title', 'description', 'image', 'date']
+  },
+  {
+    keyword: 'God',
+    filter: 'promo',
+    cardComponents: ['title', 'description', 'image', 'date', 'hitUrl']
+  },
+  {
+    keyword: 'God',
+    filter: 'author',
+    cardComponents: ['title', 'description', 'image']
+  },
+  {
+    keyword: 'Wherever',
+    filter: 'album',
+    cardComponents: ['title', 'description', 'image', 'date']
+  },
+  {
+    keyword: 'Oakley',
+    filter: 'location',
+    cardComponents: ['title', 'description', 'image', 'serviceTimes', 'directionsLink']
+  },
+  {
+    keyword: 'IKR',
+    filter: 'podcast',
+    cardComponents: ['title', 'description', 'image']
+  }
+]
+
+function verifyCardHasComponent(resultCard, component) {
+  switch (component) {
+    case 'title':
+      resultCard.title.should('be.visible').and('have.prop', 'href');
+      break;
+    case 'description':
+      resultCard.description.should('be.visible');
+      break;
+    case 'hitUrl':
+      resultCard.hitUrl.should('be.visible');
+      break;
+    case 'image':
+      resultCard.image.should('be.visible');
+      break;
+    case 'imageTimestampOverlay':
+      resultCard.imageTimestampOverlay.should('be.visible');
+      break;
+    case 'date':
+      resultCard.date.should('be.visible');
+      break;
+    case 'series':
+      resultCard.series.should('be.visible');
+      break;
+    case 'seriesDate':
+      resultCard.seriesDate.should('be.visible');
+      break;
+    case 'category':
+      resultCard.category.should('be.visible');
+      break;
+    case 'author':
+      resultCard.author.should('be.visible');
+      break;
+    case 'serviceTimes':
+      resultCard.serviceTimes.should('be.visible');
+      break;
+    case 'directionsLink':
+      resultCard.directionsLink.should('be.visible');
+      break;
+    default:
+      throw new Error(`Display validation for content "${component}" does not exist yet.`);
+  }
+}
+
+// function reloadAndSearchIfDifferentKeyword(currentKeyword, newKeyword) {
+//   if(currentKeyword !== newKeyword){
+//     cy.visit('http://localhost:3000/');
+//     search.clearedSearchField.type(type.keyword);
+//     currentKeyword = type.keyword;
+//   }
+// }
 
 describe('Search results can be filtered by type and cards are formatted correctly', function () {
   let search;
+  let currentKeyword;
   before(function () {
     // cy.visit('/firstimpressions');
 
@@ -13,188 +127,29 @@ describe('Search results can be filtered by type and cards are formatted correct
 
     //TODO build for /search so can serve locally
     cy.visit('http://localhost:3000/');///search');
-    search = SearchPanelFactory.SearchPage();
-    search.clearedSearchField.type('God');
-    //search.showMoreFilters.click();
   })
 
   beforeEach(function () {
-    SearchPanelFactory.SearchPage();
-  })
-
-  it('Tests Page filter and card layout', function () {
-    search.getFilterByName('page').click();
-    search.selectedFilterLabel.should('have.text', 'page');
-    search.resultList.first().as('firstPage');
-
-    const firstCard = new ResultCard('firstPage');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.hitUrl.should('be.visible');
-  })
-
-  it('Tests Message filter and card layout', function () {
-    search.getFilterByName('message').click();
-    search.selectedFilterLabel.should('have.text', 'message');
-    search.resultList.first().as('firstMessage');
-
-    const firstCard = new ResultCard('firstMessage');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.series.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.imageTimestampOverlay.should('be.visible');
-    firstCard.date.should('be.visible');
-  })
-
-  it('Tests Series filter and card layout', function () {
-    search.getFilterByName('series').click();
-    search.selectedFilterLabel.should('have.text', 'series');
-    search.resultList.first().as('firstSeries');
-
-    const firstCard = new ResultCard('firstSeries');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.seriesDate.should('be.visible');
-  })
-
-  it('Tests Video filter and card layout', function () {
-    search.getFilterByName('video').click();
-    search.selectedFilterLabel.should('have.text', 'video');
-    search.resultList.first().as('firstVideo');
-
-    const firstCard = new ResultCard('firstVideo');
-    firstCard.category.should('be.visible');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.imageTimestampOverlay.should('be.visible');
-    firstCard.date.should('be.visible');
-  })
-
-  it('Tests Article filter and card layout', function () {
-    search.getFilterByName('article').click();
-    search.selectedFilterLabel.should('have.text', 'article');
-    search.resultList.first().as('firstArticle');
-
-    const firstCard = new ResultCard('firstArticle');
-    firstCard.category.should('be.visible');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.author.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.imageTimestampOverlay.should('be.visible');
-    firstCard.date.should('be.visible');
-  })
-
-  it('Tests Episode filter and card layout', function () {
-    search.getFilterByName('episode').click();
-    search.selectedFilterLabel.should('have.text', 'episode');
-    search.resultList.first().as('firstEpisode');
-
-    const firstCard = new ResultCard('firstEpisode');
-    firstCard.category.should('be.visible');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.imageTimestampOverlay.should('be.visible');
-    firstCard.date.should('be.visible');
-  })
-
-  it('Tests Song filter and card layout', function () {
-    search.getFilterByName('song').click();
-    search.selectedFilterLabel.should('have.text', 'song');
-    search.resultList.first().as('firstSong');
-
-    const firstCard = new ResultCard('firstSong');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.date.should('be.visible');
-  })
-
-  it('Tests Promo filter and card layout', function () {
-    search.getFilterByName('promo').click();
-    search.selectedFilterLabel.should('have.text', 'promo');
-    search.resultList.first().as('firstPromo');
-
-    const firstCard = new ResultCard('firstPromo');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.date.should('be.visible');
-    firstCard.hitUrl.should('be.visible');
-  })
-
-  it('Tests Author filter and card layout', function () {
-    search.getFilterByName('author').click();
-    search.selectedFilterLabel.should('have.text', 'author');
-    search.resultList.first().as('firstAuthor');
-
-    const firstCard = new ResultCard('firstAuthor');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
-  })
-})
-
-//podcast, category
-describe('Search results can be filtered by type and cards are formatted correctly (smaller categories)', function () {
-  let search;
-  beforeEach(function () {
-    // cy.visit('/firstimpressions');
-
-    // //DE6720 - force open the modal
-    // cy.get('button[data-target="#searchModal"]').first().click({ force: true });
-    // search = SearchPanelFactory.MobileSharedHeaderSearchModal();
-
-    //TODO build for /search so can serve locally
-    cy.visit('http://localhost:3000/');///search');
     search = SearchPanelFactory.SearchPage();
+    // search.clearedSearchField.type('God');
   })
 
-  it('Tests Album filter and card layout', function () {
-    search.clearedSearchField.type('Whatever');
-    search.showMoreFilters.click();
+  resultContentSpecs.forEach(type => {
+    it(`Tests ${type.filter} filter and card layout`, function () {
+      if(currentKeyword !== type.keyword){
+        cy.visit('http://localhost:3000/');
+        search.clearedSearchField.type(type.keyword);
+        currentKeyword = type.keyword;
+      }
 
-    search.getFilterByName('album').click();
-    search.selectedFilterLabel.should('have.text', 'album');
-    search.resultList.first().as('firstAlbum');
+      search.getFilterByName(type.filter).click(); //TODO need to wait for filter to apply before any further assertions
+      search.selectedFilterLabel.should('have.text', type.filter);
+      search.resultList.first().as(`first${type.filter}Card`);
 
-    const firstCard = new ResultCard('firstAlbum');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.date.should('be.visible');
-  })
-
-  it('Tests Location filter and card layout', function () {
-    search.clearedSearchField.type('Oakley');
-    search.showMoreFilters.click();
-
-    search.getFilterByName('location').click();
-    search.selectedFilterLabel.should('have.text', 'location');
-    search.resultList.first().as('firstLocation');
-
-    const firstCard = new ResultCard('firstLocation');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
-    firstCard.serviceTimes.should('be.visible');
-    firstCard.directionsLink.should('be.visible').and('have.prop', 'href');
-  })
-
-  it('Tests Podcast filter and card layout', function () {
-    search.clearedSearchField.type('IKR');
-
-    search.getFilterByName('podcast').click();
-    search.selectedFilterLabel.should('have.text', 'podcast');
-    search.resultList.first().as('firstPodcast');
-
-    const firstCard = new ResultCard('firstPodcast');
-    firstCard.title.should('be.visible').and('have.prop', 'href');
-    firstCard.description.should('be.visible');
-    firstCard.image.should('be.visible');
+      const firstCard = new ResultCard(`first${type.filter}Card`);
+      type.cardComponents.forEach(content => {
+        verifyCardHasComponent(firstCard, content);
+      })
+    })
   })
 })

--- a/cypress/integration/searchOverlay/result_card_format_spec.js
+++ b/cypress/integration/searchOverlay/result_card_format_spec.js
@@ -1,4 +1,4 @@
-import { SearchPanelFactory, ResultCard, SearchFilterHelper } from "../../support/SearchPanel";
+import { SearchPanelFactory, ResultCard } from "../../support/SearchPanel";
 
 //Tests the results are formatted by content
 const resultContentSpecs = [

--- a/cypress/integration/searchOverlay/result_card_format_spec.js
+++ b/cypress/integration/searchOverlay/result_card_format_spec.js
@@ -64,6 +64,12 @@ const resultContentSpecs = [
   }
 ]
 
+const card = [{
+  keyword: 'Wherever',
+  filter: 'album',
+  cardComponents: ['title', 'description', 'image', 'date']
+}]
+
 function verifyCardHasComponent(resultCard, component) {
   switch (component) {
     case 'title':
@@ -113,7 +119,7 @@ describe('Search results can be filtered by type and cards are formatted correct
   let search;
   let currentKeyword;
   before(function () {
-    // cy.visit('/firstimpressions');
+    // cy.visit('/prayer');
 
     // //DE6720 - force open the modal
     // cy.get('button[data-target="#searchModal"]').first().click({ force: true });
@@ -128,7 +134,6 @@ describe('Search results can be filtered by type and cards are formatted correct
     // search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   })
 
-  Cypress._.times(1, i => {
   resultContentSpecs.forEach(type => {
     it(`Tests ${type.filter} filter and card layout`, function () {
       if (currentKeyword !== type.keyword) {
@@ -138,14 +143,11 @@ describe('Search results can be filtered by type and cards are formatted correct
       }
 
       search.filters.selectFilter(type.filter).then(() => {
-          search.resultList.first().as(`first${type.filter}Card`);
-
-          const firstCard = new ResultCard(`first${type.filter}Card`);
-          type.cardComponents.forEach(content => {
-            verifyCardHasComponent(firstCard, content);
-          })
-      })
-    })
-  })
-})
-})
+        const firstCard = search.results.firstCard;
+        type.cardComponents.forEach(content => {
+          verifyCardHasComponent(firstCard, content);
+        });
+      });
+    });
+  });
+});

--- a/cypress/integration/searchOverlay/result_card_format_spec.js
+++ b/cypress/integration/searchOverlay/result_card_format_spec.js
@@ -1,4 +1,4 @@
-import { SearchPanelFactory, ResultCard } from "../../support/SearchPanel";
+import { SearchPanelFactory, ResultCard, SearchFilterHelper } from "../../support/SearchPanel";
 
 //Tests the results are formatted by content
 const resultContentSpecs = [
@@ -107,13 +107,7 @@ function verifyCardHasComponent(resultCard, component) {
   }
 }
 
-// function reloadAndSearchIfDifferentKeyword(currentKeyword, newKeyword) {
-//   if(currentKeyword !== newKeyword){
-//     cy.visit('http://localhost:3000/');
-//     search.clearedSearchField.type(type.keyword);
-//     currentKeyword = type.keyword;
-//   }
-// }
+
 
 describe('Search results can be filtered by type and cards are formatted correctly', function () {
   let search;
@@ -123,7 +117,7 @@ describe('Search results can be filtered by type and cards are formatted correct
 
     // //DE6720 - force open the modal
     // cy.get('button[data-target="#searchModal"]').first().click({ force: true });
-    // search = SearchPanelFactory.MobileSharedHeaderSearchModal();
+
 
     //TODO build for /search so can serve locally
     cy.visit('http://localhost:3000/');///search');
@@ -131,25 +125,48 @@ describe('Search results can be filtered by type and cards are formatted correct
 
   beforeEach(function () {
     search = SearchPanelFactory.SearchPage();
-    // search.clearedSearchField.type('God');
+    // search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   })
 
+  //Cypress._.times(10, i => {
   resultContentSpecs.forEach(type => {
     it(`Tests ${type.filter} filter and card layout`, function () {
-      if(currentKeyword !== type.keyword){
-        cy.visit('http://localhost:3000/');
+      if (currentKeyword !== type.keyword) {
+        cy.visit('http://localhost:3000/'); //TODO remove before merge - not needed for modal
         search.clearedSearchField.type(type.keyword);
         currentKeyword = type.keyword;
       }
 
-      search.getFilterByName(type.filter).click(); //TODO need to wait for filter to apply before any further assertions
-      search.selectedFilterLabel.should('have.text', type.filter);
-      search.resultList.first().as(`first${type.filter}Card`);
+      const pageFilter = new SearchFilterHelper('searchPanel');//TODO not liking the random alias
+      pageFilter.findFilterByName(type.filter).click();
 
-      const firstCard = new ResultCard(`first${type.filter}Card`);
-      type.cardComponents.forEach(content => {
-        verifyCardHasComponent(firstCard, content);
+      pageFilter.findFilterByName(type.filter)
+        //cy.get(pageFilter.filterAlias).click()
+        .should('have.prop', 'class', 'ais-Menu-item ais-Menu-item--selected').then(() => {
+          //search.selectedFilterLabel.should('have.text', type.filter) //Redundant
+          search.resultList.first().as(`first${type.filter}Card`);
+
+          const firstCard = new ResultCard(`first${type.filter}Card`);
+          type.cardComponents.forEach(content => {
+            verifyCardHasComponent(firstCard, content);
+          })
+       // })
       })
+
+      //search.getFilterByName(type.filter).as('filter').click();
+      //search.selectedFilterLabel.should('have.text', type.filter)
+      // search.aliasFilterByName(type.filter);
+      // cy.get(`@${type.filter}Filter`).click();
+      // cy.get(`@${type.filter}Filter`).should('have.prop', 'class', 'ais-Menu-item ais-Menu-item--selected').then(() => {
+      //   search.selectedFilterLabel.should('have.text', type.filter) //Redundant
+      //   search.resultList.first().as(`first${type.filter}Card`);
+
+      //   const firstCard = new ResultCard(`first${type.filter}Card`);
+      //   type.cardComponents.forEach(content => {
+      //     verifyCardHasComponent(firstCard, content);
+      //   })
+      // })
     })
   })
 })
+// })

--- a/cypress/integration/searchOverlay/result_card_format_spec.js
+++ b/cypress/integration/searchOverlay/result_card_format_spec.js
@@ -128,7 +128,7 @@ describe('Search results can be filtered by type and cards are formatted correct
     // search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   })
 
-  //Cypress._.times(10, i => {
+  Cypress._.times(1, i => {
   resultContentSpecs.forEach(type => {
     it(`Tests ${type.filter} filter and card layout`, function () {
       if (currentKeyword !== type.keyword) {
@@ -137,36 +137,15 @@ describe('Search results can be filtered by type and cards are formatted correct
         currentKeyword = type.keyword;
       }
 
-      const pageFilter = new SearchFilterHelper('searchPanel');//TODO not liking the random alias
-      pageFilter.findFilterByName(type.filter).click();
-
-      pageFilter.findFilterByName(type.filter)
-        //cy.get(pageFilter.filterAlias).click()
-        .should('have.prop', 'class', 'ais-Menu-item ais-Menu-item--selected').then(() => {
-          //search.selectedFilterLabel.should('have.text', type.filter) //Redundant
+      search.filters.selectFilter(type.filter).then(() => {
           search.resultList.first().as(`first${type.filter}Card`);
 
           const firstCard = new ResultCard(`first${type.filter}Card`);
           type.cardComponents.forEach(content => {
             verifyCardHasComponent(firstCard, content);
           })
-       // })
       })
-
-      //search.getFilterByName(type.filter).as('filter').click();
-      //search.selectedFilterLabel.should('have.text', type.filter)
-      // search.aliasFilterByName(type.filter);
-      // cy.get(`@${type.filter}Filter`).click();
-      // cy.get(`@${type.filter}Filter`).should('have.prop', 'class', 'ais-Menu-item ais-Menu-item--selected').then(() => {
-      //   search.selectedFilterLabel.should('have.text', type.filter) //Redundant
-      //   search.resultList.first().as(`first${type.filter}Card`);
-
-      //   const firstCard = new ResultCard(`first${type.filter}Card`);
-      //   type.cardComponents.forEach(content => {
-      //     verifyCardHasComponent(firstCard, content);
-      //   })
-      // })
     })
   })
 })
-// })
+})

--- a/cypress/integration/searchOverlay/result_card_format_spec.js
+++ b/cypress/integration/searchOverlay/result_card_format_spec.js
@@ -64,12 +64,6 @@ const resultContentSpecs = [
   }
 ]
 
-const card = [{
-  keyword: 'Wherever',
-  filter: 'album',
-  cardComponents: ['title', 'description', 'image', 'date']
-}]
-
 function verifyCardHasComponent(resultCard, component) {
   switch (component) {
     case 'title':
@@ -113,31 +107,23 @@ function verifyCardHasComponent(resultCard, component) {
   }
 }
 
-
-
 describe('Search results can be filtered by type and cards are formatted correctly', function () {
   let search;
   let currentKeyword;
   before(function () {
-    // cy.visit('/prayer');
+    cy.visit('/prayer');
 
-    // //DE6720 - force open the modal
-    // cy.get('button[data-target="#searchModal"]').first().click({ force: true });
-
-
-    //TODO build for /search so can serve locally
-    cy.visit('http://localhost:3000/');///search');
+    //DE6720 - force open the modal
+    cy.get('button[data-target="#searchModal"]').first().click({ force: true });
   })
 
   beforeEach(function () {
-    search = SearchPanelFactory.SearchPage();
-    // search = SearchPanelFactory.MobileSharedHeaderSearchModal();
+    search = SearchPanelFactory.MobileSharedHeaderSearchModal();
   })
 
   resultContentSpecs.forEach(type => {
     it(`Tests ${type.filter} filter and card layout`, function () {
       if (currentKeyword !== type.keyword) {
-        cy.visit('http://localhost:3000/'); //TODO remove before merge - not needed for modal
         search.clearedSearchField.type(type.keyword);
         currentKeyword = type.keyword;
       }

--- a/cypress/integration/searchOverlay/result_card_format_spec.js
+++ b/cypress/integration/searchOverlay/result_card_format_spec.js
@@ -1,0 +1,200 @@
+import { SearchPanelFactory, ResultCard, TheFilter } from "../../support/SearchPanel";
+
+//Tests the results are formatted by content
+
+describe('Search results can be filtered by type and cards are formatted correctly', function () {
+  let search;
+  before(function () {
+    // cy.visit('/firstimpressions');
+
+    // //DE6720 - force open the modal
+    // cy.get('button[data-target="#searchModal"]').first().click({ force: true });
+    // search = SearchPanelFactory.MobileSharedHeaderSearchModal();
+
+    //TODO build for /search so can serve locally
+    cy.visit('http://localhost:3000/');///search');
+    search = SearchPanelFactory.SearchPage();
+    search.clearedSearchField.type('God');
+    //search.showMoreFilters.click();
+  })
+
+  beforeEach(function () {
+    SearchPanelFactory.SearchPage();
+  })
+
+  it('Tests Page filter and card layout', function () {
+    search.getFilterByName('page').click();
+    search.selectedFilterLabel.should('have.text', 'page');
+    search.resultList.first().as('firstPage');
+
+    const firstCard = new ResultCard('firstPage');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.hitUrl.should('be.visible');
+  })
+
+  it('Tests Message filter and card layout', function () {
+    search.getFilterByName('message').click();
+    search.selectedFilterLabel.should('have.text', 'message');
+    search.resultList.first().as('firstMessage');
+
+    const firstCard = new ResultCard('firstMessage');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.series.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.imageTimestampOverlay.should('be.visible');
+    firstCard.date.should('be.visible');
+  })
+
+  it('Tests Series filter and card layout', function () {
+    search.getFilterByName('series').click();
+    search.selectedFilterLabel.should('have.text', 'series');
+    search.resultList.first().as('firstSeries');
+
+    const firstCard = new ResultCard('firstSeries');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.seriesDate.should('be.visible');
+  })
+
+  it('Tests Video filter and card layout', function () {
+    search.getFilterByName('video').click();
+    search.selectedFilterLabel.should('have.text', 'video');
+    search.resultList.first().as('firstVideo');
+
+    const firstCard = new ResultCard('firstVideo');
+    firstCard.category.should('be.visible');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.imageTimestampOverlay.should('be.visible');
+    firstCard.date.should('be.visible');
+  })
+
+  it('Tests Article filter and card layout', function () {
+    search.getFilterByName('article').click();
+    search.selectedFilterLabel.should('have.text', 'article');
+    search.resultList.first().as('firstArticle');
+
+    const firstCard = new ResultCard('firstArticle');
+    firstCard.category.should('be.visible');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.author.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.imageTimestampOverlay.should('be.visible');
+    firstCard.date.should('be.visible');
+  })
+
+  it('Tests Episode filter and card layout', function () {
+    search.getFilterByName('episode').click();
+    search.selectedFilterLabel.should('have.text', 'episode');
+    search.resultList.first().as('firstEpisode');
+
+    const firstCard = new ResultCard('firstEpisode');
+    firstCard.category.should('be.visible');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.imageTimestampOverlay.should('be.visible');
+    firstCard.date.should('be.visible');
+  })
+
+  it('Tests Song filter and card layout', function () {
+    search.getFilterByName('song').click();
+    search.selectedFilterLabel.should('have.text', 'song');
+    search.resultList.first().as('firstSong');
+
+    const firstCard = new ResultCard('firstSong');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.date.should('be.visible');
+  })
+
+  it('Tests Promo filter and card layout', function () {
+    search.getFilterByName('promo').click();
+    search.selectedFilterLabel.should('have.text', 'promo');
+    search.resultList.first().as('firstPromo');
+
+    const firstCard = new ResultCard('firstPromo');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.date.should('be.visible');
+    firstCard.hitUrl.should('be.visible');
+  })
+
+  it('Tests Author filter and card layout', function () {
+    search.getFilterByName('author').click();
+    search.selectedFilterLabel.should('have.text', 'author');
+    search.resultList.first().as('firstAuthor');
+
+    const firstCard = new ResultCard('firstAuthor');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+  })
+})
+
+//podcast, category
+describe('Search results can be filtered by type and cards are formatted correctly (smaller categories)', function () {
+  let search;
+  beforeEach(function () {
+    // cy.visit('/firstimpressions');
+
+    // //DE6720 - force open the modal
+    // cy.get('button[data-target="#searchModal"]').first().click({ force: true });
+    // search = SearchPanelFactory.MobileSharedHeaderSearchModal();
+
+    //TODO build for /search so can serve locally
+    cy.visit('http://localhost:3000/');///search');
+    search = SearchPanelFactory.SearchPage();
+  })
+
+  it('Tests Album filter and card layout', function () {
+    search.clearedSearchField.type('Whatever');
+    search.showMoreFilters.click();
+
+    search.getFilterByName('album').click();
+    search.selectedFilterLabel.should('have.text', 'album');
+    search.resultList.first().as('firstAlbum');
+
+    const firstCard = new ResultCard('firstAlbum');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.date.should('be.visible');
+  })
+
+  it('Tests Location filter and card layout', function () {
+    search.clearedSearchField.type('Oakley');
+    search.showMoreFilters.click();
+
+    search.getFilterByName('location').click();
+    search.selectedFilterLabel.should('have.text', 'location');
+    search.resultList.first().as('firstLocation');
+
+    const firstCard = new ResultCard('firstLocation');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+    firstCard.serviceTimes.should('be.visible');
+    firstCard.directionsLink.should('be.visible').and('have.prop', 'href');
+  })
+
+  it('Tests Podcast filter and card layout', function () {
+    search.clearedSearchField.type('IKR');
+
+    search.getFilterByName('podcast').click();
+    search.selectedFilterLabel.should('have.text', 'podcast');
+    search.resultList.first().as('firstPodcast');
+
+    const firstCard = new ResultCard('firstPodcast');
+    firstCard.title.should('be.visible').and('have.prop', 'href');
+    firstCard.description.should('be.visible');
+    firstCard.image.should('be.visible');
+  })
+})

--- a/cypress/integration/searchOverlay/result_navigation_spec.js
+++ b/cypress/integration/searchOverlay/result_navigation_spec.js
@@ -17,7 +17,7 @@ describe('Searching for a keyword returns results, and the expected page opens w
     cy.url().should('eq', mediaPageUrl);
   })
 
-  it.only('Searching for a page that requires authentication opens /signin', function () {
+  it('Searching for a page that requires authentication opens /signin', function () {
     const requiresAuthUrl = `${Cypress.config().baseUrl}/preschool/register/`;
 
     search.clearedSearchField.type('Preschool Registration');

--- a/cypress/integration/searchOverlay/result_navigation_spec.js
+++ b/cypress/integration/searchOverlay/result_navigation_spec.js
@@ -3,7 +3,7 @@ import { SearchPanelFactory } from '../../support/SearchPanel'
 describe('Searching for a keyword returns results, and the expected page opens when a result is clicked', function () {
   let search;
   beforeEach(function () {
-    cy.visit('/firstimpressions');
+    cy.visit('/prayer');
 
     //DE6720 - force open the modal
     cy.get('button[data-target="#searchModal"]').first().click({ force: true });
@@ -11,34 +11,26 @@ describe('Searching for a keyword returns results, and the expected page opens w
   });
 
   it('Searching for an article opens the article in /media', function () {
-    const buyABikiniUrl = `${Cypress.config().baseUrl}/media/articles/god-told-me-to-buy-a-bikini`;
+    const mediaPageUrl = `${Cypress.config().baseUrl}/media/articles/god-told-me-to-buy-a-bikini`;
     search.clearedSearchField.type('Buy a Bikini');
-    search.getResultTitlesByHref(buyABikiniUrl).first().scrollIntoView().as('articleCard')
-      .should('exist').and('be.visible')
-      .click({ force: true });
-    cy.url().should('eq', buyABikiniUrl);
+    search.results.findByHref(mediaPageUrl).title.click({ force: true });
+    cy.url().should('eq', mediaPageUrl);
   })
 
-  it('Searching for a page that requires authentication opens /signin', function () {
-    const womanCampSignupUrl = `${Cypress.config().baseUrl}/womancamp/signup/`;
+  it.only('Searching for a page that requires authentication opens /signin', function () {
+    const requiresAuthUrl = `${Cypress.config().baseUrl}/preschool/register/`;
 
-    search.clearedSearchField.type('Woman Camp Signup');
-    search.getResultTitlesByHref(womanCampSignupUrl).first().scrollIntoView().as('womanCampSignupCard')
-      .should('exist').and('be.visible')
-      .click({ force: true });
-
+    search.clearedSearchField.type('Preschool Registration');
+    search.results.findByHref(requiresAuthUrl).title.click({ force: true });
     cy.contains('Sign In').should('exist').and('be.visible');
     cy.url().should('eq', `${Cypress.config().baseUrl}/signin`);
   })
 
   it('Searching for an ordinary Contentful page on crds.net opens that page', function () {
-    const jobsUrl = `${Cypress.config().baseUrl}/jobs/`;
+    const crdsNetUrl = `${Cypress.config().baseUrl}/jobs/`;
 
     search.clearedSearchField.type('jobs');
-    search.getResultTitlesByHref(jobsUrl).first().scrollIntoView().as('jobsCard')
-      .should('exist').and('be.visible')
-      .click({ force: true });
-
-    cy.url().should('eq', jobsUrl);
+    search.results.findByHref(crdsNetUrl).title.click({ force: true });
+    cy.url().should('eq', crdsNetUrl);
   })
 })

--- a/cypress/integration/searchOverlay/shared_header_search_icon_spec.js
+++ b/cypress/integration/searchOverlay/shared_header_search_icon_spec.js
@@ -1,9 +1,11 @@
 import { SearchPanelFactory } from '../../support/SearchPanel'
 
 describe('The Search modal should be displayed when the search icon is clicked:', function () {
-  const pagesWithSearchIcon = ['/', '/giving', '/live', '/firstimpressions'];
+  const pagesWithSearchIcon = ['/', '/giving', '/live', '/prayer'];
   pagesWithSearchIcon.forEach(url => {
     it(`From ${url}`, function () {
+      cy.ignoreUncaughtException('Uncaught TypeError: Cannot read property \'reload\' of undefined'); //Remove once DE6613 is fixed
+
       cy.visit(url);
 
       //TODO replace element selector when data-automation-id "desktop-search" is live in the shared header

--- a/cypress/integration/searchPage/search_params_in_url_spec.js
+++ b/cypress/integration/searchPage/search_params_in_url_spec.js
@@ -49,8 +49,8 @@ describe('When someone navigates to a search url:', function () {
     cy.visit(urlWithQuery);
 
     const search = SearchPanelFactory.SearchPage();
-    search.resultList.first().as('firstResult').should('be.visible');
-  })
+    search.results.firstCard.title.should('be.visible');
+  });
 
   it('With a keyword and filter in it, the page should load with the filtered results for the keyword', function () {
     const filter = 'message';
@@ -60,6 +60,6 @@ describe('When someone navigates to a search url:', function () {
 
     const search = SearchPanelFactory.SearchPage();
     search.filters.selectedFilterName.should('eq', filter);
-    search.resultList.first().as('firstResult').should('be.visible');
+    search.results.firstCard.title.should('be.visible');
   });
 });

--- a/cypress/integration/searchPage/search_params_in_url_spec.js
+++ b/cypress/integration/searchPage/search_params_in_url_spec.js
@@ -21,33 +21,25 @@ describe('When someone searches:', function () {
     const expectedUrl = getUrlWithQuery(keyword);
 
     search.clearedSearchField.type(keyword, { delay: 1000 }).then(() => {
-      cy.url().should('eq', expectedUrl);
+      search.searchField.should('have.prop', 'value', keyword).then(() => {
+        cy.url().should('eq', expectedUrl);
+      });
     });
   });
 
-  //TODO finishe testing this
-  Cypress._.times(5, i =>{
-  it.only('For a keyword and selects a filter, the keyword and filter should be included in the url', function () {
+  it('For a keyword and selects a filter, the keyword and filter should be included in the url', function () {
     const keyword = 'God';
     const filter = 'message';
+    const expectedUrl = getUrlWithQuery(keyword, filter);
+
     search.clearedSearchField.type(keyword).then(() => {
-      search.filters.selectFilter(filter).then(() =>{
-        const expectedUrl = getUrlWithQuery(keyword, filter);
-        cy.url().should('eq', expectedUrl);
+      search.searchField.should('have.prop', 'value', keyword).then(() => {
+        search.filters.selectFilter(filter).then(() => {
+          cy.url().should('eq', expectedUrl);
+        })
       })
-
-      // search.filterList.eq(1).scrollIntoView().as('searchFilter'); //Select the second filter
-
-      // cy.get('@searchFilter').find('.ais-Menu-label').should('have.prop', 'textContent').then(label => {
-      //   cy.get('@searchFilter').click();
-
-      //   const expectedUrl = getUrlWithQuery(keyword, label);
-      //   cy.url().should('eq', expectedUrl);
-      // });
     });
   });
-
-})
 });
 
 describe('When someone navigates to a search url:', function () {
@@ -61,16 +53,13 @@ describe('When someone navigates to a search url:', function () {
   })
 
   it('With a keyword and filter in it, the page should load with the filtered results for the keyword', function () {
-    const filterType = 'message';
-    const urlWithFilteredQuery = getUrlWithQuery('god', filterType);
+    const filter = 'message';
+    const urlWithFilteredQuery = getUrlWithQuery('god', filter);
 
     cy.visit(urlWithFilteredQuery);
 
     const search = SearchPanelFactory.SearchPage();
+    search.filters.selectedFilterName.should('eq', filter);
     search.resultList.first().as('firstResult').should('be.visible');
-
-    search.selectedFilter.find('.ais-Menu-label').as('selectedFilter').should('have.prop', 'textContent').then(label => {
-      expect(label).to.be.eq(filterType);
-    })
-  })
+  });
 });

--- a/cypress/integration/searchPage/search_params_in_url_spec.js
+++ b/cypress/integration/searchPage/search_params_in_url_spec.js
@@ -25,19 +25,29 @@ describe('When someone searches:', function () {
     });
   });
 
-  it('For a keyword and selects filter, the keyword and filter should be included in the url', function () {
+  //TODO finishe testing this
+  Cypress._.times(5, i =>{
+  it.only('For a keyword and selects a filter, the keyword and filter should be included in the url', function () {
     const keyword = 'God';
+    const filter = 'message';
     search.clearedSearchField.type(keyword).then(() => {
-      search.filterList.eq(1).scrollIntoView().as('searchFilter'); //Select the second filter
-
-      cy.get('@searchFilter').find('.ais-Menu-label').should('have.prop', 'textContent').then(label => {
-        cy.get('@searchFilter').click();
-
-        const expectedUrl = getUrlWithQuery(keyword, label);
+      search.filters.selectFilter(filter).then(() =>{
+        const expectedUrl = getUrlWithQuery(keyword, filter);
         cy.url().should('eq', expectedUrl);
-      });
+      })
+
+      // search.filterList.eq(1).scrollIntoView().as('searchFilter'); //Select the second filter
+
+      // cy.get('@searchFilter').find('.ais-Menu-label').should('have.prop', 'textContent').then(label => {
+      //   cy.get('@searchFilter').click();
+
+      //   const expectedUrl = getUrlWithQuery(keyword, label);
+      //   cy.url().should('eq', expectedUrl);
+      // });
     });
   });
+
+})
 });
 
 describe('When someone navigates to a search url:', function () {

--- a/cypress/support/SearchPanel.js
+++ b/cypress/support/SearchPanel.js
@@ -1,3 +1,4 @@
+//Convenience class with pre-defined search panels
 export class SearchPanelFactory {
   /**
    * Returns the SearchPanel for /search. Test must have /search open before calling this.
@@ -18,57 +19,84 @@ export class SearchPanelFactory {
 
 class SearchPanel {
   constructor (panelAlias) {
-    this._alias = panelAlias;
+    this._panelAlias = panelAlias;
   }
 
   get searchField() {
-    return cy.get(`@${this._alias}`).find('.ais-SearchBox-input');
+    return cy.get(`@${this._panelAlias}`).find('.ais-SearchBox-input');
   }
 
+  /**
+   * The search field element, guaranteed empty.
+   */
   get clearedSearchField() {
     this.searchField.as('searchField').clear();
     cy.get('@searchField').should('have.prop', 'value', '');
     return this.searchField;
   }
 
-  //X in the search field iff it has text
-  get resetIcon() {
-    return cy.get(`@${this._alias}`).find('.ais-SearchBox-reset');
-  }
-
   /**
-   * Results/Suggested
+   * The 'x' element in the search field, only available when it contains text.
    */
-  get suggestedSearchBlock() {
-    return cy.get(`@${this._alias}`).find('.suggested-container');
-  }
-
-  get noResultsBlock() {
-    return cy.get(`@${this._alias}`).find('.no-results');
-  }
-
-  get resultList() {
-    return cy.get(`@${this._alias}`).find('app-hit');
-  }
-
-  //This doesn't return the full card context - only the title line.
-  getResultTitlesByHref(href) {
-    return cy.get(`@${this._alias}`).find(`[class*="hit-title"][href="${href}"]`)
-  }
-
-  getResultCardByHref(href) {
-    return this.getResultTitlesByHref(href).parents('app-hit');
+  get resetIcon() {
+    return cy.get(`@${this._panelAlias}`).find('.ais-SearchBox-reset');
   }
 
   /**
-   * Filters
+   * Returns a helper class for interacting with result cards and content blocks in the result space.
+   */
+  get results() {
+    return new SearchResultHelper(this._panelAlias);
+  }
+
+  /**
+   * Returns a helper class for interacting with the filter menu. Only available after a successful search.
    */
   get filters() {
-    return new SearchFilterHelper(this._alias);
+    return new SearchFilterHelper(this._panelAlias);
   }
 }
 
-export class SearchFilterHelper {
+class SearchResultHelper {
+  constructor (searchPanelAlias) {
+    this._searchAlias = searchPanelAlias;
+  }
+
+  get suggestedSearchBlock() {
+    return cy.get(`@${this._searchAlias}`).find('.suggested-container');
+  }
+
+  get noResultsBlock() {
+    return cy.get(`@${this._searchAlias}`).find('.no-results');
+  }
+
+  /**
+   * The first result displayed
+   * @returns {Object} - a ResultCard wrapping the first result card displayed
+   */
+  get firstCard() {
+    cy.get(`@${this._searchAlias}`).find('app-hit')
+      .should('exist').and('be.visible')
+      .first().scrollIntoView()
+      .as('firstResultCard');
+    return new ResultCard('firstResultCard');
+  }
+
+  /**
+   * The result linking to the given href
+   * @param {string} href - the result should link to this
+   * @returns {Object} - a ResultCard wrapping the matching card
+   */
+  findByHref(href) {
+    cy.get(`@${this._searchAlias}`).find(`[class*="hit-title"][href="${href}"]`)
+      .should('exist').and('be.visible')
+      .parents('app-hit').first().scrollIntoView()
+      .as('resultCard');
+    return new ResultCard('resultCard');
+  }
+}
+
+class SearchFilterHelper {
   constructor (searchPanelAlias) {
     this._searchAlias = searchPanelAlias;
   }
@@ -115,56 +143,56 @@ export class SearchFilterHelper {
   }
 }
 
-export class ResultCard {
+class ResultCard {
   constructor (cardAlias) {
-    this._alias = cardAlias;
+    this._cardAlias = cardAlias;
   }
 
   get image() {
-    return cy.get(`@${this._alias}`).find('.hit-img');
+    return cy.get(`@${this._cardAlias}`).find('.hit-img');
   }
 
   get imageTimestampOverlay() {
-    return this.image.find('.card-stamp');
+    return this.image.should('exist').find('.card-stamp');
   }
 
   get category() {
-    return cy.get(`@${this._alias}`).find('[data-automation-id="hit-category"]');
+    return cy.get(`@${this._cardAlias}`).find('[data-automation-id="hit-category"]');
   }
 
   get title() {
-    return cy.get(`@${this._alias}`).find('.hit-title');
+    return cy.get(`@${this._cardAlias}`).find('.hit-title');
   }
 
   get description() {
-    return cy.get(`@${this._alias}`).find('[data-automation-id="hit-description"]');
+    return cy.get(`@${this._cardAlias}`).find('[data-automation-id="hit-description"]');
   }
 
   get author() {
-    return cy.get(`@${this._alias}`).find('.hit-author');
+    return cy.get(`@${this._cardAlias}`).find('.hit-author');
   }
 
   get date() {
-    return cy.get(`@${this._alias}`).find('.hit-date');
+    return cy.get(`@${this._cardAlias}`).find('.hit-date');
   }
 
   get seriesDate() {
-    return cy.get(`@${this._alias}`).find('.hit-series-date');
+    return cy.get(`@${this._cardAlias}`).find('.hit-series-date');
   }
 
   get hitUrl() {
-    return cy.get(`@${this._alias}`).find('.hit-url');
+    return cy.get(`@${this._cardAlias}`).find('.hit-url');
   }
 
   get series() {
-    return cy.get(`@${this._alias}`).find('.hit-series');
+    return cy.get(`@${this._cardAlias}`).find('.hit-series');
   }
 
   get serviceTimes() {
-    return cy.get(`@${this._alias}`).find('[data-automation-id="hit-serviceTimes"]');
+    return cy.get(`@${this._cardAlias}`).find('[data-automation-id="hit-serviceTimes"]');
   }
 
   get directionsLink() {
-    return cy.get(`@${this._alias}`).find('[data-automation-id="hit-directions"]');
+    return cy.get(`@${this._cardAlias}`).find('[data-automation-id="hit-directions"]');
   }
 }

--- a/cypress/support/SearchPanel.js
+++ b/cypress/support/SearchPanel.js
@@ -69,13 +69,26 @@ class SearchPanel {
   /**
    * Filters
    */
+  aliasFilterByName(filterName) {
+    cy.get(`@${this._alias}`).find('.ais-Menu').should('have.prop', 'textContent').then(text => {
+      if(text.includes('Show more')) {
+        cy.get(`@${this._alias}`).find('.ais-Menu-showMore').click();
+      }
+    }).then(() => {
+      const labelAlias = `${filterName}FilterLabel`;
+      cy.get(`@${this._alias}`).find('.ais-Menu-label').contains(filterName).as(labelAlias);
+      cy.get(`@${labelAlias}`).parent('.ais-Menu-link').as(`${filterName}FilterLink`);
+      cy.get(`@${filterName}FilterLink`).parent('.ais-Menu-item').as(`${filterName}Filter`) //top level
+    })
+  }
+
   getFilterByName(filterName) {
     return cy.get(`@${this._alias}`).find('.ais-Menu').should('have.prop', 'textContent').then(text => {
       if(text.includes('Show more')) {
         cy.get(`@${this._alias}`).find('.ais-Menu-showMore').click();
       }
     }).then(() => {
-      return cy.get(`@${this._alias}`).find('.ais-Menu-label').contains(filterName);
+      return cy.get(`@${this._alias}`).find('.ais-Menu-item').contains(filterName);
     })
   }
 
@@ -101,6 +114,50 @@ class SearchPanel {
 
   get showMoreFilters() {
     return cy.get(`@${this._alias}`).find('.ais-Menu-showMore');
+  }
+}
+
+/**
+ * Finds a filter and creates aliases for each component
+ */
+export class SearchFilterHelper {
+  constructor(searchPanelAlias){
+    this._searchAlias = searchPanelAlias;
+  }
+
+  //TODO test?
+  selectFilter(filterName) {
+    return this._clickShowMoreIfDisplayed().then(() => {
+      cy.get(`@${this._searchAlias}`).find('.ais-Menu-label').contains(filterName).parent()
+    })
+  }
+
+
+  //The class name of this item changes when selected, so must be re-found
+ //TODO issue here is the menu-item drops off the dom when renamed - we'd need to reget it manually after being selected
+
+  findFilterByName(filterName) {
+    return this._clickShowMoreIfDisplayed().then(() => {
+      this._filterAlias = `${filterName}Filter`;
+      this._filterLinkAlias = `${filterName}FilterLink`;
+      this._filterLabelAlias = `${filterName}FilterLabel`;
+      cy.get(`@${this._searchAlias}`).find('.ais-Menu-label').contains(filterName).as(this._filterLabelAlias);
+      cy.get(`@${this._filterLabelAlias}`).parent('.ais-Menu-link').as(this._filterLinkAlias);
+      return cy.get(`@${this._filterLinkAlias}`).parent('.ais-Menu-item').as(this._filterAlias); //top level//'.ais-Menu-item'
+
+    })
+  }
+
+  //returns the 'show more' button or the search menu bar <- not linkin this but not indented to be chained really
+  _clickShowMoreIfDisplayed() {
+    cy.get(`@${this._searchAlias}`).find('.ais-Menu').as('searchMenu');
+    return cy.get('@searchMenu').should('have.prop', 'textContent').then(text => {
+      if(text.includes('Show more')) {
+        return cy.get('@searchMenu').find('.ais-Menu-showMore').click();
+      } else {
+        return cy.get('@searchMenu');
+      }
+    })
   }
 }
 

--- a/cypress/support/SearchPanel.js
+++ b/cypress/support/SearchPanel.js
@@ -18,11 +18,11 @@ export class SearchPanelFactory {
 
 class SearchPanel {
   constructor (panelAlias) {
-    this.alias = panelAlias;
+    this._alias = panelAlias;
   }
 
   get searchField() {
-    return cy.get(`@${this.alias}`).find('.ais-SearchBox-input');
+    return cy.get(`@${this._alias}`).find('.ais-SearchBox-input');
   }
 
   get clearedSearchField() {
@@ -33,34 +33,54 @@ class SearchPanel {
 
   //X in the search field iff it has text
   get resetIcon() {
-    return cy.get(`@${this.alias}`).find('.ais-SearchBox-reset');
+    return cy.get(`@${this._alias}`).find('.ais-SearchBox-reset');
   }
 
   /**
    * Results/Suggested
    */
   get suggestedSearchBlock() {
-    return cy.get(`@${this.alias}`).find('.suggested-container');
+    return cy.get(`@${this._alias}`).find('.suggested-container');
   }
 
   get noResultsBlock() {
-    return cy.get(`@${this.alias}`).find('.no-results');
+    return cy.get(`@${this._alias}`).find('.no-results');
   }
 
   get resultList() {
-    return cy.get(`@${this.alias}`).find('app-hit');
+    return cy.get(`@${this._alias}`).find('app-hit');
   }
 
   //This doesn't return the full card context - only the title line.
   getResultTitlesByHref(href) {
-    return cy.get(`@${this.alias}`).find(`[class*="hit-title"][href="${href}"]`)
+    return cy.get(`@${this._alias}`).find(`[class*="hit-title"][href="${href}"]`)
   }
+
+  getResultCardByHref(href) {
+    return this.getResultTitlesByHref(href).parents('app-hit');
+  }
+
+  // getFirstResultCardByHref(href) {
+  //   const resultAlias = 'result';
+  //   this.getResultTitlesByHref(href).parents('app-hit').first().as(resultAlias).should('have.length', 'eq', 1); //TODO make sure the first does not fail if empty
+  //   return new ResultCard(resultAlias);
+  // }
 
   /**
    * Filters
    */
+  getFilterByName(filterName) {
+    return cy.get(`@${this._alias}`).find('.ais-Menu').should('have.prop', 'textContent').then(text => {
+      if(text.includes('Show more')) {
+        cy.get(`@${this._alias}`).find('.ais-Menu-showMore').click();
+      }
+    }).then(() => {
+      return cy.get(`@${this._alias}`).find('.ais-Menu-label').contains(filterName);
+    })
+  }
+
   get filterList() {
-    return cy.get(`@${this.alias}`).find('.ais-Menu-link')
+    return cy.get(`@${this._alias}`).find('.ais-Menu-link')
   }
 
   get filterNames() {
@@ -68,6 +88,86 @@ class SearchPanel {
   }
 
   get selectedFilter() {
-    return cy.get(`@${this.alias}`).find('[class="ais-Menu-item ais-Menu-item--selected"]').find('.ais-Menu-link')
+    return cy.get(`@${this._alias}`).find('[class="ais-Menu-item ais-Menu-item--selected"]').find('.ais-Menu-link')
+  }
+
+  get selectedFilterLabel() {
+    return cy.get(`@${this._alias}`).find('[class="ais-Menu-item ais-Menu-item--selected"]').find('.ais-Menu-label')
+  }
+
+  get filterMenu() {
+    return cy.get(`@${this._alias}`).find('.ais-Menu');
+  }
+
+  get showMoreFilters() {
+    return cy.get(`@${this._alias}`).find('.ais-Menu-showMore');
+  }
+}
+
+export class TheFilter {
+  constructor (filterMenuElement) {
+    this._menu = cy.wrap(filterMenuElement);
+  }
+
+  getFilterByName(filterName) {
+    return this._menu.find('.ais-Menu-label').contains(filterName);
+  }
+
+  get selectedFilterLabel() {
+    return this._menu.find('[class="ais-Menu-item ais-Menu-item--selected"]').find('.ais-Menu-label')
+  }
+}
+
+export class ResultCard {
+  constructor(cardAlias){
+    this._alias = cardAlias;
+  }
+
+  get image(){
+    return cy.get(`@${this._alias}`).find('.hit-img');
+  }
+
+  get imageTimestampOverlay() {
+    return this.image.find('.card-stamp');
+  }
+
+  get category() {
+    return cy.get(`@${this._alias}`).find('[data-automation-id="hit-category"]');
+  }
+
+  get title() {
+    return cy.get(`@${this._alias}`).find('.hit-title');
+  }
+
+  get description() {
+    return cy.get(`@${this._alias}`).find('[data-automation-id="hit-description"]');
+  }
+
+  get author() {
+    return cy.get(`@${this._alias}`).find('.hit-author');
+  }
+
+  get date() {
+    return cy.get(`@${this._alias}`).find('.hit-date');
+  }
+
+  get seriesDate() {
+    return cy.get(`@${this._alias}`).find('.hit-series-date');
+  }
+
+  get hitUrl() {
+    return cy.get(`@${this._alias}`).find('.hit-url');
+  }
+
+  get series() {
+    return cy.get(`@${this._alias}`).find('.hit-series');
+  }
+
+  get serviceTimes() {
+    return cy.get(`@${this._alias}`).find('[data-automation-id="hit-serviceTimes"]');
+  }
+
+  get directionsLink() {
+    return cy.get(`@${this._alias}`).find('[data-automation-id="hit-directions"]');
   }
 }

--- a/cypress/support/SearchPanel.js
+++ b/cypress/support/SearchPanel.js
@@ -60,42 +60,11 @@ class SearchPanel {
     return this.getResultTitlesByHref(href).parents('app-hit');
   }
 
-  // getFirstResultCardByHref(href) {
-  //   const resultAlias = 'result';
-  //   this.getResultTitlesByHref(href).parents('app-hit').first().as(resultAlias).should('have.length', 'eq', 1); //TODO make sure the first does not fail if empty
-  //   return new ResultCard(resultAlias);
-  // }
-
   /**
    * Filters
    */
   get filters() {
     return new SearchFilterHelper(this._alias);
-  }
-
-  //TODO convert tests using the below to the filter helper
-  get filterList() {
-    return cy.get(`@${this._alias}`).find('.ais-Menu-link')
-  }
-
-  get filterNames() {
-    return this.filterList.find('.ais-Menu-label');
-  }
-
-  get selectedFilter() {
-    return cy.get(`@${this._alias}`).find('[class="ais-Menu-item ais-Menu-item--selected"]').find('.ais-Menu-link')
-  }
-
-  get selectedFilterLabel() {
-    return cy.get(`@${this._alias}`).find('[class="ais-Menu-item ais-Menu-item--selected"]').find('.ais-Menu-label')
-  }
-
-  get filterMenu() {
-    return cy.get(`@${this._alias}`).find('.ais-Menu');
-  }
-
-  get showMoreFilters() {
-    return cy.get(`@${this._alias}`).find('.ais-Menu-showMore');
   }
 }
 
@@ -105,32 +74,42 @@ export class SearchFilterHelper {
   }
 
   /**
+   * Returns a Cypress promise for the current filter's name
+   */
+  get selectedFilterName() {
+    return cy.get(`@${this._searchAlias}`).find('[class="ais-Menu-item ais-Menu-item--selected"]').find('.ais-Menu-label').text();
+  }
+
+  /**
    * Given the filter's name, selects it and returns the selected element.
    * @param {String} filterName
    */
   selectFilter(filterName) {
-    return this._clickShowMoreIfDisplayed().then(() => {
-      return cy.get(`@${this._searchAlias}`).contains('[class="ais-Menu-item"]', filterName)
-        .click().then(() => {
-          //Clicking the filter removes the original element from the DOM, so re-find it and return
-          return cy.get(`@${this._searchAlias}`).contains('[class="ais-Menu-item ais-Menu-item--selected"]', filterName)
-        })
-    })
+    return this._filterMenu().contains('[class="ais-Menu-item"]', filterName)
+      .should('be.visible') //Verify this is visible since we need to force the click to avoid flaky tests due to erroneous 'element not visible' errors on click
+      .click({ force: true }).then(() => {
+        //Clicking the filter removes the original element from the DOM, so re-find it and return
+        return cy.get(`@${this._searchAlias}`).contains('[class="ais-Menu-item ais-Menu-item--selected"]', filterName)
+      })
   }
 
   /**
-   * Expands the list of filters if not all are displayed
+   * Returns a Cypress promise of the filter menu with all filters displayed
    * @returns the search menu element
    */
-  _clickShowMoreIfDisplayed() {
-    cy.get(`@${this._searchAlias}`).find('.ais-Menu').as('searchMenu');
-    return cy.get('@searchMenu').should('have.prop', 'textContent').then(text => {
+  _filterMenu() {
+    cy.get(`@${this._searchAlias}`).find('.ais-Menu').as('filterMenu');
+    return cy.get('@filterMenu').should('have.prop', 'textContent').then(text => {
+      //Display hidden filters
       if (text.includes('Show more')) {
-        return cy.get('@searchMenu').find('.ais-Menu-showMore').click().then(() => {
-          return cy.get('@searchMenu');
+        return cy.get('@filterMenu').find('.ais-Menu-showMore').click().then(() => {
+          //Wait until all filters are visible
+          return cy.get('@filterMenu').contains('Show less').then(() => {
+            return cy.get('@filterMenu');
+          })
         })
       } else {
-        return cy.get('@searchMenu');
+        return cy.get('@filterMenu');
       }
     })
   }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -28,3 +28,7 @@ import { Formatter } from './Formatter';
 Cypress.Commands.add('displayedText', {prevSubject: 'element'}, (subject) =>{
   return cy.wrap(subject).should('have.prop', 'textContent').then(elementText => Formatter.normalizeText(elementText));
 });
+
+Cypress.Commands.add('text', { prevSubject: 'element' }, (subject) => {
+  return cy.wrap(subject).should('have.prop', 'textContent');
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,3 +32,12 @@ Cypress.Commands.add('displayedText', {prevSubject: 'element'}, (subject) =>{
 Cypress.Commands.add('text', { prevSubject: 'element' }, (subject) => {
   return cy.wrap(subject).should('have.prop', 'textContent');
 });
+
+//Here for convenience but use sparingly - we usually want these to be thrown
+Cypress.Commands.add('ignoreUncaughtException', (expectedMessage) => {
+  cy.on('uncaught:exception', (err) => {
+    expect(err.message).to.include(expectedMessage);
+    done();
+    return false;
+  });
+});

--- a/src/app/components/hit-text/hit-text.component.html
+++ b/src/app/components/hit-text/hit-text.component.html
@@ -1,17 +1,17 @@
 <div class="hit-text text-gray-dark">
-    <span *ngIf="hit.category" class="text-gray font-size-smaller font-family-base-mid text-uppercase">{{hit.category}}</span>
+    <span *ngIf="hit.category" class="text-gray font-size-smaller font-family-base-mid text-uppercase" data-automation-id="hit-category">{{hit.category}}</span>
   <a class="hit-title component-header" href="{{hit.url}}">
     <ais-highlight class="text-gray-dark" attribute="title" [hit]="hit">
     </ais-highlight>
   </a>
   <ng-container>
-    <p *ngIf="hit.description" class="font-size-smaller push-quarter-bottom">
+    <p *ngIf="hit.description" class="font-size-smaller push-quarter-bottom" data-automation-id="hit-description">
       {{hit.description.substr(0, 180)}}
       <span *ngIf="hit.description.length > 180" style="margin-left: -3px;">...</span>
     </p>
   </ng-container>
   <ng-container>
-    <p *ngIf="hit.serviceTimes" class="font-size-smaller">
+    <p *ngIf="hit.serviceTimes" class="font-size-smaller" data-automation-id="hit-serviceTimes">
       <span class="control-label block">Service Times</span>
       {{ hit.serviceTimes }}
     </p>

--- a/src/app/components/hit/hit.component.html
+++ b/src/app/components/hit/hit.component.html
@@ -11,8 +11,8 @@
   </div>
 
   <img class="img-responsive"
-    [attr.ix-src]="hit | imgixAspectRatio" 
-    sizes="(min-width: 768px) 180px, 100vw" 
+    [attr.ix-src]="hit | imgixAspectRatio"
+    sizes="(min-width: 768px) 180px, 100vw"
     alt="{{ hit.title }}">
 </a>
 
@@ -20,7 +20,7 @@
 
 <div class="hit-meta text-gray-light">
   <p class="font-size-smaller flush">
-    <a *ngIf="hit.map_url" href="{{ hit.map_url }}" target="_blank" class="font-size-smaller flush">
+    <a *ngIf="hit.map_url" href="{{ hit.map_url }}" target="_blank" class="font-size-smaller flush" data-automation-id="hit-directions">
       Get Directions
     </a>
     <span *ngIf="hit.start_date && hit.end_date" class="hit-series-date">{{hit.start_date}} - {{hit.end_date}}</span>


### PR DESCRIPTION
- Added tests confirming the search result cards of each content type (except Category) have all the components we expect (title, description, image, etc.). The category filter is often not available since there are so few Category results, making it harder to tests. I decided to skip covering the Category results for now until they become a more likely search keyword or the number indexed increases. (Warning: These tests are slow and will add about 1min to the runtime.)
- Added some automation ids to hit components
- Hardened other tests to ensure the search was complete, filters were applied and results finished loading before testing results.
- Minor bug fixes revealed after the Contentful copydown.