### PR TITLE
DE7347 Search Tabs

### DIFF
--- a/src/app/components/tab-filter/tab-filter.component.ts
+++ b/src/app/components/tab-filter/tab-filter.component.ts
@@ -10,9 +10,13 @@ export class TabFilterComponent {
   @Input() results;
 
   transformItems(items) {
-    return items.map(item => ({
-      ...item,
-      label: item.label.replace('_', ' ')
-    }));
+    const transformedItems = [];
+    
+    for(const item of items){
+      (item as any).label = item.label.replace('_', ' ');
+      transformedItems.push(item);
+    }
+
+    return transformedItems;
   }
 }


### PR DESCRIPTION
## Problem
When you search for something and right after results are returned you try to click on one of the tabs (Author, Article, Onside Groups, etc) - first click is NOT doing anything, only when you click on any of the tabs second time it returns results related to that tab. 

## Solution 
Change map to a for loop.
[Preview](https://deploy-preview-97--int-crds-search.netlify.com/)