### PR TITLE
defect/US19010 - Cypress run on Electron in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ unitTests: &unitTest
 # Integration Test stage
 integrationTests: &integrationTest
   if: env(RUN_CYPRESS) = true
-  script: "yarn run cypress run --record --key $cypressDashboard --parallel --group crds-search-parallel --browser chrome"
+  script: "yarn run cypress run --record --key $cypressDashboard --parallel --group crds-search-parallel"
 
 jobs:
   include:


### PR DESCRIPTION
- Crome's having issues running on an old version of Cypress, so run with Cypress's built-in browser Electron instead